### PR TITLE
EXPAN-541: revolut sandbox and prod urls whitelisted.

### DIFF
--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -92,6 +92,9 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
             "https://js.stripe.com",
             "https://app.usercentrics.eu",
             "robinhood://",
+            "https://ramp.revolut.codes",
+            "https://sso.revolut.codes",
+            "https://ramp.revolut.com",
           ]
         }
         source={

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -36,5 +36,8 @@ export const WHITELISTED_ORIGINS = [
   'https://m.stripe.network',
   'https://js.stripe.com',
   'https://app.usercentrics.eu',
-  'robinhood://'
+  'robinhood://',
+  'https://ramp.revolut.codes',
+  'https://sso.revolut.codes',
+  'https://ramp.revolut.com'
 ];


### PR DESCRIPTION
## Issue ticket number and link from Jira

https://meshconnectapi.atlassian.net/browse/EXPAN-541

Implementation of RevolutConnect integration requires the whitelisting of the Revolut domains.


## Type of change

Please tick the relevant options (with an "x").

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Refactor (none of the core functionality has changed)
- [ ] Chore (adding new tests, build processes, tooling, performance)
- [ ] This change requires a documentation update

## Checklist:

Please tick the options (with an "x") of the actions which you have done. For example, it may be that an issue doesn't require new tests to be written, so you would leave option 5 unchecked:

- [ ] I have performed a self-review of my code and it meets the criteria specified by the ticket/issue
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have not changed existing tests (if so please add a description in the PR)
- [ ] New and existing unit tests pass locally with my changes
