### PR TITLE
XPR-985 add option to select language

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ const transferDestinationTokens: IntegrationAccessToken = [
 const linkSettings: LinkSettings = {
     accessTokens,
     transferDestinationTokens,
+    language: 'en'
 };
 
 export const App = () => {
@@ -118,6 +119,7 @@ export default App;
 
 
 The `LinkSettings` option allows to configure the Link behaviour:
+- `language` - Link UI language.
 - `accessTokens` - an array of `IntegrationAccessToken` objects that is used as an origin for crypto transfer flow.
 - `transferDestinationTokens` - an array of `IntegrationAccessToken` objects that is used as a destination for crypto transfer flow.
 - `disableDomainWhiteList` - a boolean flag that allows to disable origin whitelisting. By default, the origin is whitelisted, with the following domains set:

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshconnectrnsdkexample",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "private": true,
   "scripts": {
     "preinstall": "./scripts/preinstall",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.15",
+  "version": "2.1.16",
   "name": "@meshconnect/react-native-link-sdk",
   "description": "Mesh Connect React Native SDK.",
   "license": "MIT",

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -29,6 +29,7 @@ describe('LinkConnect Component', () => {
 
   it('renders correctly when linkToken and accessTokens and transferDestinationTokens are provided', () => {
     render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} settings={{
+      language: 'en',
       accessTokens: [
         {
           accountId: '1234567890',

--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         cacheMode="LOAD_NO_CACHE"
         injectedJavaScript="
     window.meshSdkPlatform='reactNative';
-    window.meshSdkVersion='2.1.15';
+    window.meshSdkVersion='2.1.16';
   "
         javaScriptEnabled={true}
         onLoadEnd={[Function]}
@@ -100,7 +100,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         }
         source={
           {
-            "uri": "https://web.getfront.com/b2b-iframe/test-account-random/broker-connect/catalog1",
+            "uri": "https://web.getfront.com/b2b-iframe/test-account-random/broker-connect/catalog1?lng=en",
           }
         }
         startInLoadingState={true}

--- a/src/hooks/useSDKCallbacks.ts
+++ b/src/hooks/useSDKCallbacks.ts
@@ -24,7 +24,7 @@ const useSDKCallbacks = (props: LinkConfiguration) => {
   useEffect(() => {
     try {
       if (props.linkToken) {
-        const decodedUrl = decode64(props.linkToken);
+        let decodedUrl = decode64(props.linkToken);
 
         if (!isValidUrl(decodedUrl)) {
           throw new Error('Invalid link token provided');
@@ -42,6 +42,10 @@ const useSDKCallbacks = (props: LinkConfiguration) => {
           setDarkTheme(style?.th === 'dark');
         }
 
+        decodedUrl = `${decodedUrl}${decodedUrl.includes('?') ? '&' : '?'}lng=${
+          props.settings?.language || 'en'
+        }`
+
         setLinkUrl(decodedUrl);
         setShowWebView(true);
       }
@@ -56,7 +60,7 @@ const useSDKCallbacks = (props: LinkConfiguration) => {
       setLinkUrl(null);
       setShowWebView(false);
     };
-  }, [props.linkToken, props.onExit]);
+  }, [props.linkToken, props.onExit, props.settings?.language]);
 
   useEffect(() => {
     const colorSchemeWatcher = Appearance.addChangeListener(({ colorScheme }) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -243,9 +243,12 @@ export interface IntegrationAccessToken {
   brokerName: string;
 }
 
+export type Language = 'en' | 'ru'
+
 export interface LinkSettings {
   accessTokens?: IntegrationAccessToken[];
   transferDestinationTokens?: IntegrationAccessToken[];
+  language?: Language;
 }
 
 export interface LinkConfiguration {


### PR DESCRIPTION
This pull request includes updates to add language support to the `LinkSettings` and increment the package version. The most important changes include adding a new `language` property to the `LinkSettings`, updating the package version, and modifying tests and snapshots to accommodate the new language property.

### Language Support:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73): Added a `language` property to the `LinkSettings` configuration to specify the UI language for the Link component. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R122)
* [`src/hooks/useSDKCallbacks.ts`](diffhunk://#diff-5c3e46d41010242b237fb2d27c90d9929bfef4f09abcee373794b4cf3d6ecab2L27-R27): Updated the `useSDKCallbacks` hook to include the `language` parameter in the link URL and handle changes to the `language` setting. [[1]](diffhunk://#diff-5c3e46d41010242b237fb2d27c90d9929bfef4f09abcee373794b4cf3d6ecab2L27-R27) [[2]](diffhunk://#diff-5c3e46d41010242b237fb2d27c90d9929bfef4f09abcee373794b4cf3d6ecab2R45-R48) [[3]](diffhunk://#diff-5c3e46d41010242b237fb2d27c90d9929bfef4f09abcee373794b4cf3d6ecab2L59-R63)
* [`src/types/index.ts`](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R246-R251): Defined a `Language` type and added an optional `language` property to the `LinkSettings` interface.

### Version Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2): Updated the package version from `2.1.15` to `2.1.16`.
* [`examples/react-native-example/package.json`](diffhunk://#diff-6205f11cc277201ec91ba87bd9f000fad5e43c1a8ded8bed35d0619e4f4646e7L3-R3): Updated the example package version to `2.1.16`.

### Test and Snapshot Updates:

* [`src/__tests__/LinkConnect.test.tsx`](diffhunk://#diff-375aa7b72093ffd4b6a1cdf1e4e514292f3319592ad79dd98b8ba88f42084cfcR32): Modified tests to include the `language` property in the `LinkConnect` component settings.
* [`src/__tests__/__snapshots__/LinkConnect.test.tsx.snap`](diffhunk://#diff-6aabd5ecd898798c10d013d08ced7e6779bb89015f5c40b7e738a0d40ecd4c65L53-R53): Updated snapshots to reflect the new `language` parameter in the link URL and package version change. [[1]](diffhunk://#diff-6aabd5ecd898798c10d013d08ced7e6779bb89015f5c40b7e738a0d40ecd4c65L53-R53) [[2]](diffhunk://#diff-6aabd5ecd898798c10d013d08ced7e6779bb89015f5c40b7e738a0d40ecd4c65L103-R103)