### PR TITLE
Open Binance mobile app auth in external browser

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -44,4 +44,5 @@ export const EXTERNALLY_OPENED_ORIGINS = [
   'https://coinbase.com',
   'https://login.coinbase.com',
   'https://api.cb-device-intelligence.com',
+  'https://app.binance.com',
 ];


### PR DESCRIPTION
Currently, Binance auth via app is stuck in an infinite loader loop because the SDK's webview seems to be handling `https://app.binance.com/*` requests, instead of opening them in the external browser. 

## Type of change

- [x] Adds origin `https://app.binance.com` to `EXTERNALLY_OPENED_ORIGINS`
