### PR TITLE
PRG-2562 workflow updates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,7 +45,7 @@ mesh-react-native-sdk/
 ├── .github/
 │   ├── pull_request_template.md
 │   └── workflows/
-│       ├── primary.yml         # CI: type-check + lint + test + build on PRs to main
+│       ├── ci.yml              # CI: type-check + lint + test + build on PRs to main
 │       └── release.yaml        # CD: publish, GitHub Release, Slack announcement
 ├── .claude/
 │   └── commands/               # Claude slash commands (bump-version)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,9 +43,10 @@ mesh-react-native-sdk/
 │   └── verify-build.js         # Validates dist/ output
 ├── dist/                       # Build output (published to npm)
 ├── .github/
+│   ├── pull_request_template.md
 │   └── workflows/
 │       ├── primary.yml         # CI: type-check + lint + test + build on PRs to main
-│       └── release.yaml        # CD: publish, tag, GitHub Release, Slack announcement
+│       └── release.yaml        # CD: publish, GitHub Release, Slack announcement
 ├── .claude/
 │   └── commands/               # Claude slash commands (bump-version)
 ├── package.json                # Version lives here — bump `version` field to release
@@ -220,13 +221,14 @@ See `RELEASE.md` for full details. Summary:
 9. Circular dependency check
 
 ### `release.yaml` — push to `main` or manual trigger
-- Detects new version (compares `version` in `package.json` to latest tag) — skips if already released
-- Validates CHANGELOG has a matching entry
-- Runs CI checks (type-check, lint, tests, build, SonarQube)
-- Publishes to npm
-- Creates and pushes git tag `X.Y.Z` (matching the version from `package.json`, without a `v` prefix)
-- Creates GitHub Release with changelog notes and full-diff link
-- Posts Slack announcement
+
+Three jobs run in sequence: `check-version` → `ci-and-publish` → `release`
+
+- **`check-version`**: Detects new version (compares `package.json` to latest git tag) — skips if already released; validates CHANGELOG has a matching entry
+- **`ci-and-publish`**: Type-check, lint, tests, build, build validation, SonarQube, then publishes to npm
+- **`release`**: Creates GitHub Release with changelog notes and full-diff link; posts Slack announcement
+
+The GitHub Release creation implicitly creates the git tag `X.Y.Z`.
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,23 @@
-## Summary
+## PR overview
 
-<Put a link to the Jira issue, or describe changes>
+<Add a link to the Jira issue and describe changes>
 
 ## Type of change
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
-- [ ] Refactor (none of the core functionality has changed)
-- [ ] Maintenance (new tests, build processes, tooling, performance)
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (existing functionality affected)
+- [ ] Maintenance (tests, build, tooling, performance)
+- [ ] Refactor (no functional changes)
 - [ ] Documentation update
 
 ## Checklist
 
 Please tick the options you have done:
 
-- [ ] I have performed a self-review of my code, and it meets the criteria specified by the ticket/issue
-- [ ] I have added comments on my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation if necessary
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have verified that all tests pass locally with my changes
-- [ ] I have tested my changes locally on both Android & iOS
+- [ ] Performed a self-review, and it meets ticket criteria
+- [ ] Hard-to-understand areas are commented
+- [ ] Documentation updated where necessary
+- [ ] Tests added that prove the fix or feature works
+- [ ] All tests pass locally
+- [ ] Tested locally on both Android & iOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,17 +62,17 @@ jobs:
       - name: Check for unused dependencies 🔍
         shell: bash {0}
         run: |
-          dependencies=$(npx -q depcheck --skip-missing)
+          dependencies=$(npm exec --ignore-scripts -q -- depcheck@1.4.7 --skip-missing)
           echo "$dependencies"
           ! echo "$dependencies" | grep -q "Unused dependencies" && (echo "OK: no unused dependencies found") || (echo "FAIL: unused dependencies found"; exit 1)
 
       - name: Check for strict licenses 🪪
         shell: bash {0}
         run: |
-          licenses=$(npx -q tldrlegal)
+          licenses=$(npm exec --ignore-scripts -q -- tldrlegal@1.0.11)
           echo "$licenses"
           declare -a strict=("Must Give Credit"  "Must Disclose Source"  "Must Include Original")
           for license in "${strict[@]}"; do echo "$licenses" | grep "$license" | grep -Eoq " 0 " && (echo "OK: $license") || (echo "FAIL: $license"; exit 1); done
 
       - name: Check for circular dependencies ♻️
-        run: npx madge --circular --no-spinner src/
+        run: npm exec --ignore-scripts -- madge@8.0.0 --circular --no-spinner src/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# This workflow runs on pull requests to the main branch and on manual triggers.
+# It performs a series of checks including type checking, linting, unit testing, SonarQube scanning,
+# building the package, checking for unused dependencies, verifying strict licenses, and checking for circular dependencies.
 name: CI
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,14 +50,15 @@ jobs:
 
           VERSION=$(node -p "require('./package.json').version")
           VERSION=$(normalize_semver "$VERSION")
-          LATEST_TAG=$(normalize_semver "$(git tag --sort=-v:refname | head -n 1)")
+          LATEST_RAW_TAG=$(git tag --sort=-v:refname | head -n 1)
+          LATEST_TAG=$(normalize_semver "$LATEST_RAW_TAG")
 
           if [[ ! "$VERSION" =~ $SEMVER_RE ]]; then
             echo "::error::version in package.json must be MAJOR.MINOR.PATCH; got: ${VERSION:-<empty>}"
             exit 1
           fi
           if [[ -n "$LATEST_TAG" && ! "$LATEST_TAG" =~ $SEMVER_RE ]]; then
-            echo "::error::Latest git tag must be MAJOR.MINOR.PATCH or unset; normalize or fix tag: $(git tag --sort=-v:refname | head -n 1)"
+            echo "::error::Latest git tag must be MAJOR.MINOR.PATCH or unset; normalize or fix tag: $LATEST_RAW_TAG"
             exit 1
           fi
 
@@ -81,7 +82,7 @@ jobs:
             echo "::error::version in package.json ($VERSION) is not greater than the latest tag ($LATEST_TAG) — accidental downgrade?"
             exit 1
           elif [[ -n "$(git tag -l "$VERSION")" ]]; then
-            echo "::error::Tag $VERSION already exists — bump the version in package.json before releasing"
+            echo "::error::Tag $VERSION already exists, means that is was released before — accidental reuse?"
             exit 1
           else
             echo "New version detected: $VERSION (previous: $LATEST_TAG)"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,19 +123,15 @@ jobs:
           fi
           echo "Changelog entry for ${VERSION} found ✓"
 
-  release:
+  ci-and-publish:
     needs: check-version
     if: needs.check-version.outputs.new_version == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout 🎾
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Node 📚
         uses: actions/setup-node@v4
@@ -171,13 +167,18 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Create git tag 🏷️
-        run: |
-          VERSION="${{ needs.check-version.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$VERSION"
-          git push origin "$VERSION"
+  release:
+    needs: [check-version, ci-and-publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout 🎾
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Create GitHub Release 🚀
         id: create_release
@@ -194,7 +195,7 @@ jobs:
 
           ${CHANGELOG_SECTION}
 
-          **Full Changelog**: https://github.com/FrontFin/mesh-react-native-sdk/compare/${PREV_TAG}...${VERSION}
+          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${VERSION}
           EOF
 
           gh release create "$VERSION" \
@@ -202,8 +203,7 @@ jobs:
             --notes-file /tmp/release_notes.md \
             --target main
 
-          RELEASE_URL="https://github.com/FrontFin/mesh-react-native-sdk/releases/tag/${VERSION}"
-          echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+          echo "release_url=https://github.com/${{ github.repository }}/releases/tag/${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Send release announcement to Slack 📣
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,6 @@
+# This workflow runs on pushes to the main branch and on demand.
+# It checks if the version in package.json has been updated compared to the latest git tag,
+# validates the changelog, runs the CI checks, publishes to npm, creates a GitHub release, and sends a Slack announcement.
 name: Release
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
             echo "::error::version in package.json ($VERSION) is not greater than the latest tag ($LATEST_TAG) — accidental downgrade?"
             exit 1
           elif [[ -n "$(git tag -l "$VERSION")" ]]; then
-            echo "::error::Tag $VERSION already exists, means that is was released before — accidental reuse?"
+            echo "::error::Tag $VERSION already exists, means that it was released before — accidental reuse?"
             exit 1
           else
             echo "New version detected: $VERSION (previous: $LATEST_TAG)"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,6 +135,8 @@ jobs:
     steps:
       - name: Checkout 🎾
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Node 📚
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout 🎾
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout 🎾
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Node 📚
         uses: actions/setup-node@v4
@@ -179,7 +179,7 @@ jobs:
 
     steps:
       - name: Checkout 🎾
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 
 1. Run `/bump-version` — bumps version according to [Semantic Versioning](https://semver.org/) and prepends a new entry to `CHANGELOG.md`.
 2. Merge into `main`.
-3. The release workflow starts automatically on merge to `main`. Optionally trigger [Release](https://github.com/FrontFin/mesh-react-native-sdk/actions/workflows/release.yaml) workflow manually.
+3. The release workflow starts automatically on merge to `main`. Optionally run [Release](https://github.com/FrontFin/mesh-react-native-sdk/actions/workflows/release.yaml) workflow manually.
 4. Verify the new version appears on [npm](https://www.npmjs.com/package/@meshconnect/react-native-link-sdk).
 
 ## ✍🏼️ Manually
@@ -12,7 +12,7 @@
 1. Update `version` in [package.json](./package.json) according to [Semantic Versioning](https://semver.org/).
 2. Add a new entry to `CHANGELOG.md`.
 3. Merge into `main`.
-4. The release workflow starts automatically on merge to `main`. Optionally trigger [Release](https://github.com/FrontFin/mesh-react-native-sdk/actions/workflows/release.yaml) workflow manually.
+4. The release workflow starts automatically on merge to `main`. Optionally run [Release](https://github.com/FrontFin/mesh-react-native-sdk/actions/workflows/release.yaml) workflow manually.
 5. Verify the new version appears on [npm](https://www.npmjs.com/package/@meshconnect/react-native-link-sdk).
 
 > [!NOTE]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,10 +9,11 @@
 
 ## ✍🏼️ Manually
 
-1. Update `version` in [package.json](./package.json) according to [Semantic Versioning](https://semver.org/) and prepend a matching entry to `CHANGELOG.md`.
-2. Merge into `main`.
-3. The release workflow starts automatically on merge to `main`. Optionally trigger [Release](https://github.com/FrontFin/mesh-react-native-sdk/actions/workflows/release.yaml) workflow manually.
-4. Verify the new version appears on [npm](https://www.npmjs.com/package/@meshconnect/react-native-link-sdk).
+1. Update `version` in [package.json](./package.json) according to [Semantic Versioning](https://semver.org/).
+2. Add a new entry to `CHANGELOG.md`.
+3. Merge into `main`.
+4. The release workflow starts automatically on merge to `main`. Optionally trigger [Release](https://github.com/FrontFin/mesh-react-native-sdk/actions/workflows/release.yaml) workflow manually.
+5. Verify the new version appears on [npm](https://www.npmjs.com/package/@meshconnect/react-native-link-sdk).
 
 > [!NOTE]
 > Publication on npm is usually available within a minute after the workflow finishes.


### PR DESCRIPTION
## PR overview

https://meshconnectapi.atlassian.net/browse/PRG-2562

Aligns the release workflow:
- Split the single release job into two: `ci-and-publish` (checks + publish) and `release` (GitHub Release + Slack)
- Removed the "Create git tag" step — the tag is now created implicitly by gh release create
- Replaced hardcoded FrontFin/mesh-react-native-sdk with `${{ github.repository }}`
- Updated `pull_request_template.md`

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing functionality affected)
- [x] Maintenance (tests, build, tooling, performance)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Checklist

Please tick the options you have done:

- [ ] Performed a self-review, and it meets ticket criteria
- [ ] Hard-to-understand areas are commented
- [ ] Documentation updated where necessary
- [ ] Tests added that prove the fix or feature works
- [ ] All tests pass locally
- [ ] Tested locally on both Android & iOS
