### PR TITLE
PRG-2378: drop appopener from externally-opened origins

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -40,7 +40,6 @@ export const WHITELISTED_ORIGINS = [
 
 export const EXTERNALLY_OPENED_ORIGINS = [
   'https://link.trustwallet.com',
-  'https://appopener.meshconnect.com',
   'https://coinbase.com',
   'https://login.coinbase.com',
   'https://api.cb-device-intelligence.com',


### PR DESCRIPTION
Implements PR 2a of 8 for [PRG-2378](https://meshconnectapi.atlassian.net/browse/PRG-2378).

The `appopener.meshconnect.com` host is being retired. The host appeared in `EXTERNALLY_OPENED_ORIGINS` as an allow-list entry permitting the WebView to navigate there. Since the backend no longer constructs URLs to that host (PR 1 of 8 in `FrontBackEnd`), this entry is dead weight.

## Changes
Removes `'https://appopener.meshconnect.com'` from `EXTERNALLY_OPENED_ORIGINS` in `src/constant.ts`.

## Compatibility
Allow-list shrink, not a contract change. Old shipped SDKs stay safe.

## Reviewer checklist
- [ ] CI green
- [ ] Bump version (minor) + update CHANGELOG if applicable
- [ ] Coordinate release with PRG-2378 rollout

PR 2a of 8.

[PRG-2378]: https://meshconnectapi.atlassian.net/browse/PRG-2378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ