### PR TITLE
chore: remove hardcoded Revolut origins from WebView whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Updated the `WhitelistedOrigins.kt`
+- Removed hardcoded Revolut origins from the WebView domain whitelist.
 
 ## 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Mesh Connect React Native SDK are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.4.2
+
+### Changed
+
+- Updated the `WhitelistedOrigins.kt`
+
 ## 2.4.1
 
 ### Added

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshconnect-react-native-example",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.1",
+  "version": "2.4.2",
   "name": "@meshconnect/react-native-link-sdk",
   "description": "Mesh Connect React Native SDK.",
   "license": "MIT",

--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         domStorageEnabled={true}
         injectedJavaScript="
     window.meshSdkPlatform='reactNative';
-    window.meshSdkVersion='2.4.1';
+    window.meshSdkVersion='2.4.2';
   "
         javaScriptEnabled={true}
         onContentProcessDidTerminate={[Function]}
@@ -93,9 +93,6 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
             "https://js.stripe.com",
             "https://app.usercentrics.eu",
             "robinhood://",
-            "https://ramp.revolut.codes",
-            "https://sso.revolut.codes",
-            "https://ramp.revolut.com",
           ]
         }
         source={

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -33,9 +33,6 @@ export const WHITELISTED_ORIGINS = [
   'https://js.stripe.com',
   'https://app.usercentrics.eu',
   'robinhood://',
-  'https://ramp.revolut.codes',
-  'https://sso.revolut.codes',
-  'https://ramp.revolut.com',
 ];
 
 export const EXTERNALLY_OPENED_ORIGINS = [


### PR DESCRIPTION
## PR overview

Removes the hardcoded Revolut dev origins from the WebView domain whitelist (`src/constant.ts`) and bumps the SDK version to `2.4.2`.

- Dropped the Revolut origins from the whitelisted origins list
- Bumped `version` to `2.4.2` in `package.json` and the example app
- Updated the `LinkConnect` test snapshot accordingly
- Added a `2.4.2` entry to `CHANGELOG.md`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing functionality affected)
- [ ] Maintenance (tests, build, tooling, performance)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Checklist

Please tick the options you have done:

- [x] Performed a self-review, and it meets ticket criteria
- [ ] Hard-to-understand areas are commented
- [ ] Documentation updated where necessary
- [ ] Tests added that prove the fix or feature works
- [x] All tests pass locally
- [x] Tested locally on both Android & iOS
