### PR TITLE
PRG-3107 open Binance app auth in external browser

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,7 +46,7 @@ mesh-react-native-sdk/
 │   ├── pull_request_template.md
 │   └── workflows/
 │       ├── ci.yml              # CI: type-check + lint + test + build on PRs to main
-│       └── release.yaml        # CD: publish, GitHub Release, Slack announcement
+│       └── release.yml         # CD: publish, GitHub Release, Slack announcement
 ├── .claude/
 │   └── commands/               # Claude slash commands (bump-version)
 ├── package.json                # Version lives here — bump `version` field to release
@@ -220,7 +220,7 @@ See `RELEASE.md` for full details. Summary:
 8. License check
 9. Circular dependency check
 
-### `release.yaml` — push to `main` or manual trigger
+### `release.yml` — push to `main` or manual trigger
 
 Three jobs run in sequence: `check-version` → `ci-and-publish` → `release`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the Mesh Connect React Native SDK are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.4.3
+
+### Fixed
+
+- Binance app auth now opens in the external browser instead of hanging in the WebView.
+
+### Changed
+
+- Hardened external-origin matching against lookalike-host and path spoofing.
+
 ## 2.4.2
 
 ### Removed

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshconnect-react-native-example",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.2",
+  "version": "2.4.3",
   "name": "@meshconnect/react-native-link-sdk",
   "description": "Mesh Connect React Native SDK.",
   "license": "MIT",

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -118,6 +118,19 @@ describe('LinkConnect Component', () => {
     });
   });
 
+  it('onShouldStartLoadWithRequest opens Binance app auth externally (PRG-3107)', async () => {
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    await waitFor(() => {
+      const result = getByTestId('webview').props.onShouldStartLoadWithRequest({
+        url: 'https://app.binance.com/en/oauth/authorize?client_id=mesh',
+      });
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        'https://app.binance.com/en/oauth/authorize?client_id=mesh'
+      );
+      expect(result).toBe(false);
+    });
+  });
+
   it('emits webViewLoadFailed event on WebView onError', async () => {
     const mockOnEvent = jest.fn();
     const { getByTestId } = render(

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -118,7 +118,7 @@ describe('LinkConnect Component', () => {
     });
   });
 
-  it('onShouldStartLoadWithRequest opens Binance app auth externally (PRG-3107)', async () => {
+  it('onShouldStartLoadWithRequest opens Binance app auth externally', async () => {
     const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
     await waitFor(() => {
       const result = getByTestId('webview').props.onShouldStartLoadWithRequest({

--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         domStorageEnabled={true}
         injectedJavaScript="
     window.meshSdkPlatform='reactNative';
-    window.meshSdkVersion='2.4.2';
+    window.meshSdkVersion='2.4.3';
   "
         javaScriptEnabled={true}
         onContentProcessDidTerminate={[Function]}

--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
             "robinhood://",
           ]
         }
+        setSupportMultipleWindows={false}
         source={
           {
             "uri": "https://web.getfront.com/b2b-iframe/test-account-random/broker-connect/catalog1?platform=reactNative",

--- a/src/__tests__/externallyOpenedOrigin.test.ts
+++ b/src/__tests__/externallyOpenedOrigin.test.ts
@@ -47,6 +47,24 @@ describe('isExternallyOpenedOrigin', () => {
         'https://sandbox.meshconnect.com/authorize/Coinbase/../CoinbaseEvil'
       )
     ).toBe(false);
+    // percent-encoded dot-segment (%2e%2e) must NOT escape the pin either
+    expect(
+      isExternallyOpenedOrigin(
+        'https://sandbox.meshconnect.com/authorize/Coinbase/%2e%2e/CoinbaseEvil'
+      )
+    ).toBe(false);
+    // percent-encoded slash (%2f) hiding a dot-segment must NOT escape the pin
+    expect(
+      isExternallyOpenedOrigin(
+        'https://sandbox.meshconnect.com/authorize/Coinbase%2f..%2fCoinbaseEvil'
+      )
+    ).toBe(false);
+    // malformed percent-encoding fails closed
+    expect(
+      isExternallyOpenedOrigin(
+        'https://sandbox.meshconnect.com/authorize/Coinbase/%zz'
+      )
+    ).toBe(false);
   });
 
   it('rejects host lookalike attacks', () => {

--- a/src/__tests__/externallyOpenedOrigin.test.ts
+++ b/src/__tests__/externallyOpenedOrigin.test.ts
@@ -14,7 +14,7 @@ describe('isExternallyOpenedOrigin', () => {
     });
   });
 
-  it('returns true for Binance app auth URLs (PRG-3107)', () => {
+  it('returns true for Binance app auth URLs', () => {
     expect(isExternallyOpenedOrigin('https://app.binance.com')).toBe(true);
     expect(
       isExternallyOpenedOrigin(
@@ -41,6 +41,12 @@ describe('isExternallyOpenedOrigin', () => {
         'https://sandbox.meshconnect.com/authorize/CoinbaseEvil'
       )
     ).toBe(false);
+    // a dot-segment must NOT escape the pin (normalizes to /authorize/CoinbaseEvil)
+    expect(
+      isExternallyOpenedOrigin(
+        'https://sandbox.meshconnect.com/authorize/Coinbase/../CoinbaseEvil'
+      )
+    ).toBe(false);
   });
 
   it('rejects host lookalike attacks', () => {
@@ -53,6 +59,10 @@ describe('isExternallyOpenedOrigin', () => {
     // userinfo trick: real host is evil.com, not app.binance.com
     expect(
       isExternallyOpenedOrigin('https://app.binance.com@evil.com/oauth')
+    ).toBe(false);
+    // multi-@ authority: host is what follows the LAST @, so this is evil.com
+    expect(
+      isExternallyOpenedOrigin('https://app.binance.com@x@evil.com/oauth')
     ).toBe(false);
   });
 

--- a/src/__tests__/externallyOpenedOrigin.test.ts
+++ b/src/__tests__/externallyOpenedOrigin.test.ts
@@ -21,6 +21,12 @@ describe('isExternallyOpenedOrigin', () => {
         'https://app.binance.com/en/oauth/authorize?client_id=mesh'
       )
     ).toBe(true);
+    // Android hands off via the bnc:// scheme (QR scanner deep link)
+    expect(
+      isExternallyOpenedOrigin(
+        'bnc://app.binance.com/qrcode/qr_scan?bundle_target=1'
+      )
+    ).toBe(true);
   });
 
   it('honors path-pinned origins on a segment boundary', () => {
@@ -81,6 +87,14 @@ describe('isExternallyOpenedOrigin', () => {
     // multi-@ authority: host is what follows the LAST @, so this is evil.com
     expect(
       isExternallyOpenedOrigin('https://app.binance.com@x@evil.com/oauth')
+    ).toBe(false);
+    // bnc:// scheme must still host-match: a lookalike host is rejected
+    expect(isExternallyOpenedOrigin('bnc://evil.com/qrcode/qr_scan')).toBe(
+      false
+    );
+    // backslash lookalike: a browser reads \ as /, so the real host is evil.com
+    expect(
+      isExternallyOpenedOrigin('https://evil.com\\@app.binance.com/oauth')
     ).toBe(false);
   });
 

--- a/src/__tests__/externallyOpenedOrigin.test.ts
+++ b/src/__tests__/externallyOpenedOrigin.test.ts
@@ -1,0 +1,72 @@
+import { isExternallyOpenedOrigin } from '../utils';
+
+describe('isExternallyOpenedOrigin', () => {
+  it('returns true for allowlisted origins', () => {
+    const urls = [
+      'https://link.trustwallet.com/wc?uri=abc',
+      'https://coinbase.com/oauth/authorize?client_id=test',
+      'https://login.coinbase.com/signin',
+      'https://api.cb-device-intelligence.com/collect',
+    ];
+
+    urls.forEach((url) => {
+      expect(isExternallyOpenedOrigin(url)).toBe(true);
+    });
+  });
+
+  it('returns true for Binance app auth URLs (PRG-3107)', () => {
+    expect(isExternallyOpenedOrigin('https://app.binance.com')).toBe(true);
+    expect(
+      isExternallyOpenedOrigin(
+        'https://app.binance.com/en/oauth/authorize?client_id=mesh'
+      )
+    ).toBe(true);
+  });
+
+  it('honors path-pinned origins on a segment boundary', () => {
+    // exact and nested paths match
+    expect(
+      isExternallyOpenedOrigin(
+        'https://sandbox.meshconnect.com/authorize/Coinbase'
+      )
+    ).toBe(true);
+    expect(
+      isExternallyOpenedOrigin(
+        'https://sandbox.meshconnect.com/authorize/Coinbase/callback'
+      )
+    ).toBe(true);
+    // a lookalike path segment must NOT match
+    expect(
+      isExternallyOpenedOrigin(
+        'https://sandbox.meshconnect.com/authorize/CoinbaseEvil'
+      )
+    ).toBe(false);
+  });
+
+  it('rejects host lookalike attacks', () => {
+    expect(
+      isExternallyOpenedOrigin('https://app.binance.com.evil.com/oauth')
+    ).toBe(false);
+    expect(
+      isExternallyOpenedOrigin('https://coinbase.com.evil.com/authorize')
+    ).toBe(false);
+    // userinfo trick: real host is evil.com, not app.binance.com
+    expect(
+      isExternallyOpenedOrigin('https://app.binance.com@evil.com/oauth')
+    ).toBe(false);
+  });
+
+  it('rejects scheme mismatches and non-listed origins', () => {
+    expect(isExternallyOpenedOrigin('http://app.binance.com')).toBe(false);
+    expect(isExternallyOpenedOrigin('https://example.com')).toBe(false);
+    expect(isExternallyOpenedOrigin('https://web.meshconnect.com/catalog')).toBe(
+      false
+    );
+  });
+
+  it('returns false for non-url and empty inputs', () => {
+    expect(isExternallyOpenedOrigin('about:blank')).toBe(false);
+    expect(isExternallyOpenedOrigin('not a url')).toBe(false);
+    expect(isExternallyOpenedOrigin('')).toBe(false);
+  });
+});

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -9,11 +9,11 @@ import { SDKViewContainer } from './SDKViewContainer';
 import type { LinkConfiguration } from '../';
 import { useSDKCallbacks } from '../hooks/useSDKCallbacks';
 import { sdkSpecs } from '../utils/sdkConfig';
+import { isExternallyOpenedOrigin } from '../utils';
 import {
   DARK_THEME_COLOR_BOTTOM,
   LIGHT_THEME_COLOR_BOTTOM,
   WHITELISTED_ORIGINS,
-  EXTERNALLY_OPENED_ORIGINS,
 } from '../constant';
 
 const LoadingComponentWebview = ({ darkTheme }: { darkTheme: boolean }) => {
@@ -118,9 +118,7 @@ export const LinkConnect = (props: LinkConfiguration) => {
           {...whiteListProps}
           onNavigationStateChange={handleNavState}
           onShouldStartLoadWithRequest={(req) => {
-            if (
-              EXTERNALLY_OPENED_ORIGINS.some((orig) => req.url.startsWith(orig))
-            ) {
+            if (isExternallyOpenedOrigin(req.url)) {
               Linking.openURL(req.url);
               return false;
             }

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -120,10 +120,13 @@ export const LinkConnect = (props: LinkConfiguration) => {
           onShouldStartLoadWithRequest={(req) => {
             if (isExternallyOpenedOrigin(req.url)) {
               // These origins are https and are handled by the browser, so a
-              // rejection is unlikely; catch + warn anyway so a failed open
-              // can't surface as an unhandled promise rejection.
+              // rejection is unlikely; catch anyway so a failed open can't
+              // surface as an unhandled promise rejection. Warn in dev only, to
+              // avoid noise in integrators' production builds.
               void Linking.openURL(req.url).catch((err) => {
-                console.warn('Failed to open external URL', req.url, err);
+                if (__DEV__) {
+                  console.warn('Failed to open external URL', req.url, err);
+                }
               });
               return false;
             }

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -119,7 +119,9 @@ export const LinkConnect = (props: LinkConfiguration) => {
           onNavigationStateChange={handleNavState}
           onShouldStartLoadWithRequest={(req) => {
             if (isExternallyOpenedOrigin(req.url)) {
-              Linking.openURL(req.url);
+              // Voided + caught so a failed open (no handler app) can't surface
+              // as an unhandled promise rejection.
+              void Linking.openURL(req.url).catch(() => undefined);
               return false;
             }
             return req.url.startsWith('http');

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -117,12 +117,14 @@ export const LinkConnect = (props: LinkConfiguration) => {
           injectedJavaScript={injectedScript}
           {...whiteListProps}
           onNavigationStateChange={handleNavState}
+          setSupportMultipleWindows={false}
           onShouldStartLoadWithRequest={(req) => {
             if (isExternallyOpenedOrigin(req.url)) {
-              // These origins are https and are handled by the browser, so a
-              // rejection is unlikely; catch anyway so a failed open can't
-              // surface as an unhandled promise rejection. Warn in dev only, to
-              // avoid noise in integrators' production builds.
+              // These origins open in the browser or a native app (e.g. the
+              // Binance app via the bnc:// deep link), so a rejection is
+              // unlikely; catch anyway so a failed open can't surface as an
+              // unhandled promise rejection. Warn in dev only, to avoid noise
+              // in integrators' production builds.
               void Linking.openURL(req.url).catch((err) => {
                 if (__DEV__) {
                   console.warn('Failed to open external URL', req.url, err);

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -119,9 +119,12 @@ export const LinkConnect = (props: LinkConfiguration) => {
           onNavigationStateChange={handleNavState}
           onShouldStartLoadWithRequest={(req) => {
             if (isExternallyOpenedOrigin(req.url)) {
-              // Voided + caught so a failed open (no handler app) can't surface
-              // as an unhandled promise rejection.
-              void Linking.openURL(req.url).catch(() => undefined);
+              // These origins are https and are handled by the browser, so a
+              // rejection is unlikely; catch + warn anyway so a failed open
+              // can't surface as an unhandled promise rejection.
+              void Linking.openURL(req.url).catch((err) => {
+                console.warn('Failed to open external URL', req.url, err);
+              });
               return false;
             }
             return req.url.startsWith('http');

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -42,4 +42,5 @@ export const EXTERNALLY_OPENED_ORIGINS = [
   'https://api.cb-device-intelligence.com',
   'https://sandbox.meshconnect.com/authorize/Coinbase',
   'https://app.binance.com', // Binance auth hands off to the Binance mobile app; must open externally, not in the WebView
+  'bnc://app.binance.com', // Binance app deep link (Android QR-scan handoff uses the bnc:// scheme)
 ];

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -41,4 +41,5 @@ export const EXTERNALLY_OPENED_ORIGINS = [
   'https://login.coinbase.com',
   'https://api.cb-device-intelligence.com',
   'https://sandbox.meshconnect.com/authorize/Coinbase',
+  'https://app.binance.com', // Binance auth hands off to the Binance mobile app; must open externally, not in the WebView
 ];

--- a/src/utils/externallyOpenedOrigin.ts
+++ b/src/utils/externallyOpenedOrigin.ts
@@ -17,7 +17,7 @@ const parseUrlParts = (url: string): UrlParts | null => {
   }
 
   const authority = match[2]
-    .replace(/^[^@]*@/, '') // drop userinfo
+    .replace(/^.*@/, '') // drop userinfo up to the last @ (host is what follows)
     .replace(/:\d+$/, ''); // drop port
 
   return {
@@ -33,7 +33,9 @@ const parseUrlParts = (url: string): UrlParts | null => {
  * prevent lookalike attacks (e.g. https://app.binance.com.evil.com must NOT
  * match https://app.binance.com). When an allowlisted origin pins a path, the
  * URL path must equal it or be nested under it on a segment boundary, so
- * /authorize/CoinbaseEvil does not match /authorize/Coinbase.
+ * /authorize/CoinbaseEvil does not match /authorize/Coinbase. Paths containing
+ * `.`/`..` segments are rejected against a pinned origin so a dot-segment can't
+ * escape the pin after normalization (e.g. /authorize/Coinbase/../CoinbaseEvil).
  */
 export const isExternallyOpenedOrigin = (url: string): boolean => {
   const target = parseUrlParts(url);
@@ -52,6 +54,11 @@ export const isExternallyOpenedOrigin = (url: string): boolean => {
     }
 
     if (allowed.path && allowed.path !== '/') {
+      // Reject dot-segments so a path can't escape the pin after normalization.
+      const segments = target.path.split('/');
+      if (segments.includes('.') || segments.includes('..')) {
+        return false;
+      }
       const base = allowed.path.endsWith('/')
         ? allowed.path
         : `${allowed.path}/`;

--- a/src/utils/externallyOpenedOrigin.ts
+++ b/src/utils/externallyOpenedOrigin.ts
@@ -1,0 +1,65 @@
+import { EXTERNALLY_OPENED_ORIGINS } from '../constant';
+
+interface UrlParts {
+  scheme: string;
+  host: string;
+  path: string;
+}
+
+// Parse scheme, host and path without relying on the URL global, which is only
+// partially implemented on some React Native runtimes. Userinfo and port are
+// stripped so the host compares cleanly (and lookalikes can't sneak in via
+// userinfo, e.g. https://app.binance.com@evil.com resolves to host evil.com).
+const parseUrlParts = (url: string): UrlParts | null => {
+  const match = /^([a-z][a-z0-9+.-]*):\/\/([^/?#]+)([^?#]*)/i.exec(url);
+  if (!match) {
+    return null;
+  }
+
+  const authority = match[2]
+    .replace(/^[^@]*@/, '') // drop userinfo
+    .replace(/:\d+$/, ''); // drop port
+
+  return {
+    scheme: match[1].toLowerCase(),
+    host: authority.toLowerCase(),
+    path: match[3] || '',
+  };
+};
+
+/**
+ * True when `url` should be opened in the external browser / native app rather
+ * than loaded inside the SDK WebView. Scheme and host are matched exactly to
+ * prevent lookalike attacks (e.g. https://app.binance.com.evil.com must NOT
+ * match https://app.binance.com). When an allowlisted origin pins a path, the
+ * URL path must equal it or be nested under it on a segment boundary, so
+ * /authorize/CoinbaseEvil does not match /authorize/Coinbase.
+ */
+export const isExternallyOpenedOrigin = (url: string): boolean => {
+  const target = parseUrlParts(url);
+  if (!target) {
+    return false;
+  }
+
+  return EXTERNALLY_OPENED_ORIGINS.some((origin) => {
+    const allowed = parseUrlParts(origin);
+    if (!allowed) {
+      return false;
+    }
+
+    if (target.scheme !== allowed.scheme || target.host !== allowed.host) {
+      return false;
+    }
+
+    if (allowed.path && allowed.path !== '/') {
+      const base = allowed.path.endsWith('/')
+        ? allowed.path
+        : `${allowed.path}/`;
+      if (target.path !== allowed.path && !target.path.startsWith(base)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+};

--- a/src/utils/externallyOpenedOrigin.ts
+++ b/src/utils/externallyOpenedOrigin.ts
@@ -34,8 +34,9 @@ const parseUrlParts = (url: string): UrlParts | null => {
  * match https://app.binance.com). When an allowlisted origin pins a path, the
  * URL path must equal it or be nested under it on a segment boundary, so
  * /authorize/CoinbaseEvil does not match /authorize/Coinbase. Paths containing
- * `.`/`..` segments are rejected against a pinned origin so a dot-segment can't
- * escape the pin after normalization (e.g. /authorize/Coinbase/../CoinbaseEvil).
+ * `.`/`..` segments (literal or percent-encoded) are rejected against a pinned
+ * origin so a dot-segment can't escape the pin after normalization (e.g.
+ * /authorize/Coinbase/../CoinbaseEvil or the %2e%2e-encoded equivalent).
  */
 export const isExternallyOpenedOrigin = (url: string): boolean => {
   const target = parseUrlParts(url);
@@ -55,7 +56,15 @@ export const isExternallyOpenedOrigin = (url: string): boolean => {
 
     if (allowed.path && allowed.path !== '/') {
       // Reject dot-segments so a path can't escape the pin after normalization.
-      const segments = target.path.split('/');
+      // Decode first (failing closed on malformed input) so percent-encoded
+      // segments like %2e%2e (`..`) or %2f (`/`) can't slip past the check.
+      let decodedPath: string;
+      try {
+        decodedPath = decodeURIComponent(target.path);
+      } catch {
+        return false;
+      }
+      const segments = decodedPath.split('/');
       if (segments.includes('.') || segments.includes('..')) {
         return false;
       }

--- a/src/utils/externallyOpenedOrigin.ts
+++ b/src/utils/externallyOpenedOrigin.ts
@@ -11,7 +11,11 @@ interface UrlParts {
 // stripped so the host compares cleanly (and lookalikes can't sneak in via
 // userinfo, e.g. https://app.binance.com@evil.com resolves to host evil.com).
 const parseUrlParts = (url: string): UrlParts | null => {
-  const match = /^([a-z][a-z0-9+.-]*):\/\/([^/?#]+)([^?#]*)/i.exec(url);
+  // Mirror WHATWG: a browser treats backslashes as forward slashes, so
+  // https://evil.com\@app.binance.com really opens evil.com. Normalize first so
+  // that lookalike can't be mis-parsed as app.binance.com and opened externally.
+  const normalized = url.replace(/\\/g, '/');
+  const match = /^([a-z][a-z0-9+.-]*):\/\/([^/?#]+)([^?#]*)/i.exec(normalized);
   if (!match) {
     return null;
   }
@@ -26,6 +30,11 @@ const parseUrlParts = (url: string): UrlParts | null => {
     path: match[3] || '',
   };
 };
+
+// Parse the allowlist once at module load rather than on every navigation.
+const ALLOWED_ORIGINS: UrlParts[] = EXTERNALLY_OPENED_ORIGINS.map(
+  parseUrlParts
+).filter((parts): parts is UrlParts => parts !== null);
 
 /**
  * True when `url` should be opened in the external browser / native app rather
@@ -44,12 +53,7 @@ export const isExternallyOpenedOrigin = (url: string): boolean => {
     return false;
   }
 
-  return EXTERNALLY_OPENED_ORIGINS.some((origin) => {
-    const allowed = parseUrlParts(origin);
-    if (!allowed) {
-      return false;
-    }
-
+  return ALLOWED_ORIGINS.some((allowed) => {
     if (target.scheme !== allowed.scheme || target.host !== allowed.host) {
       return false;
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 export * from './base64';
+export * from './externallyOpenedOrigin';
 export * from './isUrl';
 export * from './urlHelpers';
 export * from './styleHelpers';


### PR DESCRIPTION
## Overview

[PRG-3107](https://meshconnectapi.atlassian.net/browse/PRG-3107) - open Binance mobile app auth in external browser

Binance auth (app.binance.com) was being handled by the SDK WebView and got stuck in an infinite loader. This adds app.binance.com to EXTERNALLY_OPENED_ORIGINS so it opens externally and hands off to the Binance app. Finalizes #88.

While here, the origin check moved from a naive `startsWith` to an exact scheme+host+path matcher (mirrors the Flutter SDK) so an allowlisted origin can't be spoofed by a lookalike (e.g. app.binance.com.evil.com). Added unit tests for the Binance case and the lookalike/userinfo/path attacks.

### 🎨 Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing functionality affected)
- [ ] Maintenance (tests, build, tooling, performance)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

### 👌 Checklist

- [x] I've performed a self-review, and it meets ticket criteria.
- [x] I've commented hard-to-understand areas.
- [x] I've updated documentation where necessary.
- [x] I've added tests that prove the fix or feature works.
- [x] I've tested the changes on a physical device or emulator.

[PRG-3107]: https://meshconnectapi.atlassian.net/browse/PRG-3107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ