### PR TITLE
PRG-3113: migrate RN SDK npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
 
       # OIDC trusted publishing requires npm >= 11.5.1; pin for reproducible releases
       - name: Pin npm for OIDC 📌
-        run: npm install -g npm@11.5.1
+        run: npm install -g npm@11.5.1 --ignore-scripts
 
       - name: Publish to npm 🎉
         # No NODE_AUTH_TOKEN: publish authenticates via npm OIDC trusted publishing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,9 @@ jobs:
     if: needs.check-version.outputs.new_version == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write # required for npm OIDC trusted publishing
+      contents: read
 
     steps:
       - name: Checkout 🎾
@@ -140,7 +143,7 @@ jobs:
       - name: Node 📚
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install node modules 📦
@@ -166,10 +169,13 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+      # OIDC trusted publishing requires npm >= 11.5.1; pin for reproducible releases
+      - name: Pin npm for OIDC 📌
+        run: npm install -g npm@11.5.1
+
       - name: Publish to npm 🎉
-        run: cd dist && yarn publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # No NODE_AUTH_TOKEN: publish authenticates via npm OIDC trusted publishing.
+        run: cd dist && npm publish --access public --provenance --registry https://registry.npmjs.org
 
   release:
     needs: [check-version, ci-and-publish]


### PR DESCRIPTION
## Overview

[PRG-3113](https://meshconnectapi.atlassian.net/browse/PRG-3113) - migrate npm publish from the long-lived classic `NPM_TOKEN` to npm OIDC trusted publishing (same P1 supply-chain fix shipped for mesh-web-sdk under PRG-2759).

The `ci-and-publish` job previously ran `yarn publish` (yarn v1) with `NODE_AUTH_TOKEN: secrets.NPM_TOKEN`. yarn v1 does not support OIDC, so this converts the publish to `npm publish` over OIDC:
- add `id-token: write` (+ `contents: read`) permission
- bump Node 18 → 20 (npm ≥ 11.5.1 needs Node ≥ 20) and pin `npm@11.5.1`
- `npm publish --provenance --registry https://registry.npmjs.org` (`--provenance` as a CLI flag since `build.js` strips `publishConfig` from `dist/`)
- drop `NODE_AUTH_TOKEN`/`NPM_TOKEN` so publish authenticates via OIDC

Follow-up (not in this PR): npm org owner must register the GitHub Actions Trusted Publisher for `@meshconnect/react-native-link-sdk` (repo `mesh-react-native-sdk`, workflow `release.yml`) before the next publish.

### 🎨 Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing functionality affected)
- [x] Maintenance (tests, build, tooling, performance)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

### 👌 Checklist

- [x] I've performed a self-review, and it meets ticket criteria.
- [ ] I've commented hard-to-understand areas.
- [ ] I've updated documentation where necessary.
- [ ] I've added tests that prove the fix or feature works.
- [ ] I've tested the changes on a physical device or emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PRG-3113]: https://meshconnectapi.atlassian.net/browse/PRG-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ