### PR TITLE
PRG-3183 open OAuth/onramp popups on iOS WebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Mesh Connect React Native SDK are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.4.4
+
+### Fixed
+
+- OAuth and onramp handoffs (e.g. the Coinbase deposit flow) now open in the external browser on iOS instead of hanging on the loading screen.
+
 ## 2.4.3
 
 ### Fixed

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshconnect-react-native-example",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,86 +1,39 @@
 {
-  "version": "2.4.3",
-  "name": "@meshconnect/react-native-link-sdk",
-  "description": "Mesh Connect React Native SDK.",
-  "license": "MIT",
-  "author": "Mesh Connect, Inc",
-  "repository": "https://github.com/FrontFin/mesh-react-native-sdk.git",
-  "homepage": "https://github.com/FrontFin/mesh-react-native-sdk",
-  "main": "src/index.ts",
-  "typings": "src/types.ts",
-  "module": "src/index.ts",
+  "name": "meshconnect-react-native-example",
+  "version": "2.4.4",
+  "private": true,
   "scripts": {
-    "build": "rm -rf dist && tsc --build && node scripts/build.js",
-    "build:watch": "tsc --build --watch",
-    "check:build": "node scripts/verify-build.js",
-    "clean": "tsc --build --clean",
-    "clean:modules": "rm -rf node_modules",
-    "lint": "eslint --ext .js,.ts,.tsx ./src",
-    "test": "jest --passWithNoTests",
-    "publish:npm": "yarn build && cd dist && yarn publish --access public",
-    "prepare": "husky install",
-    "types:check": "tsc --noEmit"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "node scripts/pre-commit.js"
-    }
-  },
-  "prettier": {
-    "printWidth": 80,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "es5"
-  },
-  "keywords": [
-    "mesh-connect",
-    "react-native-sdk"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "engines": {
-    "node": ">=16"
-  },
-  "packageManager": "yarn@1.22.17",
-  "peerDependencies": {
-    "react": ">=16",
-    "react-native": ">=0.60",
-    "react-native-webview": "*"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.29.7",
-    "@babel/plugin-transform-private-methods": "^7.27.1",
-    "@babel/preset-env": "^7.29.3",
-    "@babel/runtime": "^7.29.2",
-    "@react-native/eslint-config": "^0.72.2",
-    "@react-native/metro-config": "^0.72.11",
-    "@testing-library/react-native": "^12.2.2",
-    "@tsconfig/react-native": "^3.0.9",
-    "@types/jest": "^30.0.0",
-    "@types/node": "^20",
-    "@types/react": "^18.0.24",
-    "@types/react-test-renderer": "^18.0.0",
-    "babel-jest": "^29.7.0",
-    "eslint": "8.57.1",
-    "eslint-plugin-import": "^2.28.1",
-    "husky": "^8.0.3",
-    "jest": "^29.7.0",
-    "metro-react-native-babel-preset": "^0.77.0",
-    "prettier": "^2.4.1",
-    "react": "18.2.0",
-    "react-native": "^0.75",
-    "react-test-renderer": "^18.2.0",
-    "ts-jest": "^29.4.9",
-    "typescript": "^5.1.6"
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "lint": "eslint .",
+    "start": "react-native start",
+    "test": "jest",
+    "reinstall": "rm -rf ./node_modules && yarn && yarn start"
   },
   "dependencies": {
-    "query-string": "7",
-    "react-native-webview": "^13.16.1"
+    "@meshconnect/react-native-link-sdk": "../../dist",
+    "react": "18.3.1",
+    "react-native": "0.75.5",
+    "react-native-webview": "^13.10.5"
   },
-  "resolutions": {
-    "js-yaml": "^4.3.0",
-    "fast-xml-parser": ">=5.9.3",
-    "picomatch": "^4.0.4"
+  "devDependencies": {
+    "@babel/core": "^7.29.4",
+    "@babel/preset-env": "^7.29.4",
+    "@babel/runtime": "^7.29.4",
+    "@react-native/babel-preset": "0.75.5",
+    "@react-native/eslint-config": "0.75.5",
+    "@react-native/metro-config": "0.75.5",
+    "@react-native/typescript-config": "0.75.5",
+    "@types/react": "^18.2.6",
+    "@types/react-test-renderer": "^18.0.0",
+    "babel-jest": "^29.6.3",
+    "eslint": "^8.19.0",
+    "jest": "^29.6.3",
+    "prettier": "2.8.8",
+    "react-test-renderer": "18.3.1",
+    "typescript": "5.0.4"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,39 +1,86 @@
 {
-  "name": "meshconnect-react-native-example",
   "version": "2.4.4",
-  "private": true,
+  "name": "@meshconnect/react-native-link-sdk",
+  "description": "Mesh Connect React Native SDK.",
+  "license": "MIT",
+  "author": "Mesh Connect, Inc",
+  "repository": "https://github.com/FrontFin/mesh-react-native-sdk.git",
+  "homepage": "https://github.com/FrontFin/mesh-react-native-sdk",
+  "main": "src/index.ts",
+  "typings": "src/types.ts",
+  "module": "src/index.ts",
   "scripts": {
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
-    "lint": "eslint .",
-    "start": "react-native start",
-    "test": "jest",
-    "reinstall": "rm -rf ./node_modules && yarn && yarn start"
+    "build": "rm -rf dist && tsc --build && node scripts/build.js",
+    "build:watch": "tsc --build --watch",
+    "check:build": "node scripts/verify-build.js",
+    "clean": "tsc --build --clean",
+    "clean:modules": "rm -rf node_modules",
+    "lint": "eslint --ext .js,.ts,.tsx ./src",
+    "test": "jest --passWithNoTests",
+    "publish:npm": "yarn build && cd dist && yarn publish --access public",
+    "prepare": "husky install",
+    "types:check": "tsc --noEmit"
   },
-  "dependencies": {
-    "@meshconnect/react-native-link-sdk": "../../dist",
-    "react": "18.3.1",
-    "react-native": "0.75.5",
-    "react-native-webview": "^13.10.5"
+  "husky": {
+    "hooks": {
+      "pre-commit": "node scripts/pre-commit.js"
+    }
   },
-  "devDependencies": {
-    "@babel/core": "^7.29.4",
-    "@babel/preset-env": "^7.29.4",
-    "@babel/runtime": "^7.29.4",
-    "@react-native/babel-preset": "0.75.5",
-    "@react-native/eslint-config": "0.75.5",
-    "@react-native/metro-config": "0.75.5",
-    "@react-native/typescript-config": "0.75.5",
-    "@types/react": "^18.2.6",
-    "@types/react-test-renderer": "^18.0.0",
-    "babel-jest": "^29.6.3",
-    "eslint": "^8.19.0",
-    "jest": "^29.6.3",
-    "prettier": "2.8.8",
-    "react-test-renderer": "18.3.1",
-    "typescript": "5.0.4"
+  "prettier": {
+    "printWidth": 80,
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "es5"
+  },
+  "keywords": [
+    "mesh-connect",
+    "react-native-sdk"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=16"
+  },
+  "packageManager": "yarn@1.22.17",
+  "peerDependencies": {
+    "react": ">=16",
+    "react-native": ">=0.60",
+    "react-native-webview": "*"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.29.7",
+    "@babel/plugin-transform-private-methods": "^7.27.1",
+    "@babel/preset-env": "^7.29.3",
+    "@babel/runtime": "^7.29.2",
+    "@react-native/eslint-config": "^0.72.2",
+    "@react-native/metro-config": "^0.72.11",
+    "@testing-library/react-native": "^12.2.2",
+    "@tsconfig/react-native": "^3.0.9",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^20",
+    "@types/react": "^18.0.24",
+    "@types/react-test-renderer": "^18.0.0",
+    "babel-jest": "^29.7.0",
+    "eslint": "8.57.1",
+    "eslint-plugin-import": "^2.28.1",
+    "husky": "^8.0.3",
+    "jest": "^29.7.0",
+    "metro-react-native-babel-preset": "^0.77.0",
+    "prettier": "^2.4.1",
+    "react": "18.2.0",
+    "react-native": "^0.75",
+    "react-test-renderer": "^18.2.0",
+    "ts-jest": "^29.4.9",
+    "typescript": "^5.1.6"
+  },
+  "dependencies": {
+    "query-string": "7",
+    "react-native-webview": "^13.16.1"
+  },
+  "resolutions": {
+    "js-yaml": "^4.3.0",
+    "fast-xml-parser": ">=5.9.3",
+    "picomatch": "^4.0.4"
   }
 }

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -173,6 +173,19 @@ describe('LinkConnect Component', () => {
     });
   });
 
+  it('onOpenWindow swallows a failed external open (no unhandled rejection)', async () => {
+    (Linking.openURL as jest.Mock).mockRejectedValueOnce(new Error('no handler'));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    await waitFor(() => {
+      getByTestId('webview').props.onOpenWindow({
+        nativeEvent: { targetUrl: 'https://login.coinbase.com/oauth2/auth' },
+      });
+    });
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    warn.mockRestore();
+  });
+
   it('emits webViewLoadFailed event on WebView onError', async () => {
     const mockOnEvent = jest.fn();
     const { getByTestId } = render(

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -131,6 +131,48 @@ describe('LinkConnect Component', () => {
     });
   });
 
+  it('onOpenWindow opens the popup target URL externally (OAuth handoff)', async () => {
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    await waitFor(() => {
+      getByTestId('webview').props.onOpenWindow({
+        nativeEvent: {
+          targetUrl: 'https://login.coinbase.com/oauth2/auth?client_id=mesh',
+        },
+      });
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        'https://login.coinbase.com/oauth2/auth?client_id=mesh'
+      );
+    });
+  });
+
+  it('onOpenWindow ignores a non-http target (e.g. about:blank)', async () => {
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    (Linking.openURL as jest.Mock).mockClear();
+    await waitFor(() => {
+      getByTestId('webview').props.onOpenWindow({
+        nativeEvent: { targetUrl: 'about:blank' },
+      });
+      expect(Linking.openURL).not.toHaveBeenCalled();
+    });
+  });
+
+  it('onOpenWindow ignores dangerous / non-https schemes', async () => {
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    (Linking.openURL as jest.Mock).mockClear();
+    await waitFor(() => {
+      const webview = getByTestId('webview');
+      [
+        'javascript:alert(1)',
+        'data:text/html,<script>alert(1)</script>',
+        'http://insecure.example.com',
+        'meshapp://deeplink',
+      ].forEach((targetUrl) => {
+        webview.props.onOpenWindow({ nativeEvent: { targetUrl } });
+      });
+      expect(Linking.openURL).not.toHaveBeenCalled();
+    });
+  });
+
   it('emits webViewLoadFailed event on WebView onError', async () => {
     const mockOnEvent = jest.fn();
     const { getByTestId } = render(

--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -51,8 +51,9 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         domStorageEnabled={true}
         injectedJavaScript="
     window.meshSdkPlatform='reactNative';
-    window.meshSdkVersion='2.4.3';
+    window.meshSdkVersion='2.4.4';
   "
+        javaScriptCanOpenWindowsAutomatically={true}
         javaScriptEnabled={true}
         onContentProcessDidTerminate={[Function]}
         onError={[Function]}
@@ -60,6 +61,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         onLoadEnd={[Function]}
         onMessage={[Function]}
         onNavigationStateChange={[Function]}
+        onOpenWindow={[Function]}
         onRenderProcessGone={[Function]}
         onShouldStartLoadWithRequest={[Function]}
         originWhitelist={

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -118,6 +118,11 @@ export const LinkConnect = (props: LinkConfiguration) => {
           {...whiteListProps}
           onNavigationStateChange={handleNavState}
           setSupportMultipleWindows={false}
+          // iOS blocks a gestureless window.open (e.g. link-v2's Coinbase
+          // deposit handoff fires it after an async fetch, outside the tap).
+          // Without this, WebKit never calls the popup delegate, so
+          // onOpenWindow below never fires and the deposit dead-ends.
+          javaScriptCanOpenWindowsAutomatically={true}
           onShouldStartLoadWithRequest={(req) => {
             if (isExternallyOpenedOrigin(req.url)) {
               // These origins open in the browser or a native app (e.g. the
@@ -133,6 +138,24 @@ export const LinkConnect = (props: LinkConfiguration) => {
               return false;
             }
             return req.url.startsWith('http');
+          }}
+          onOpenWindow={({ nativeEvent }) => {
+            // link-v2 hands off OAuth/onramp via window.open('_blank') on a
+            // catalog tap. On iOS the WebView surfaces that here instead of
+            // navigating, so without forwarding it the popup is dropped and the
+            // flow dead-ends. Open it in the external browser, same
+            // as the in-page "Re-open" fallback and the Android
+            // onShouldStartLoadWithRequest path. Require https so a blank,
+            // opaque, or non-https (javascript:/data:/custom-scheme) target is
+            // ignored.
+            const { targetUrl } = nativeEvent;
+            if (targetUrl?.startsWith('https://')) {
+              void Linking.openURL(targetUrl).catch((err) => {
+                if (__DEV__) {
+                  console.warn('Failed to open external URL', targetUrl, err);
+                }
+              });
+            }
           }}
           domStorageEnabled={true}
           onError={({ nativeEvent }) => {


### PR DESCRIPTION
## Overview

[PRG-3183](https://meshconnectapi.atlassian.net/browse/PRG-3183) - Mobile app hangs after selecting a CEX during deposit

On iOS, link-v2 hands off OAuth/onramp via `window.open('_blank')` (the Coinbase Ramp deposit handoff fires it gesturelessly), and react-native-webview dropped these, so the deposit dead-ended on the "Checking the status of your deposit" screen and only the manual "Re-open" link worked.

This enables `javaScriptCanOpenWindowsAutomatically` so iOS surfaces the gestureless open, and adds an `onOpenWindow` handler that opens the target URL (https only) in the external browser, matching the Android `onShouldStartLoadWithRequest` path and the native iOS/Android SDKs. Verified on a physical iPhone: both the catalog-tap OAuth and the Coinbase Ramp deposit flow open the browser automatically.

### 🎨 Type of change

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing functionality affected)
- [ ] Maintenance (tests, build, tooling, performance)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

### 👌 Checklist

- [X] I've performed a self-review, and it meets ticket criteria.
- [X] I've commented hard-to-understand areas.
- [X] I've updated documentation where necessary.
- [X] I've added tests that prove the fix or feature works.
- [X] I've tested the changes on a physical device or emulator.


[PRG-3183]: https://meshconnectapi.atlassian.net/browse/PRG-3183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ