### PR TITLE
PRG-2297 add 'system' language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Mesh Connect React Native SDK are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 2.5.0
+## 2.4.6
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Mesh Connect React Native SDK are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.5.0
+
+### Added
+
+- `settings.language` now accepts `'system'` to follow the device's language.
+
 ## 2.4.5
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ export default App;
 
 The `LinkSettings` option allows to configure the Link behaviour:
 
-- `language` - Link UI language.
+- `language` - Link UI language as a BCP-47 tag (e.g. 'en', 'en-US'). Accepts 'system' to follow the device language.
 - `displayFiatCurrency` - a preferred display fiat currency
 - `theme` - Link UI colour theme. Accepts: 'light', 'dark', 'system'.
 - `accessTokens` - an array of `IntegrationAccessToken` objects that is used as an origin for crypto transfer flow.

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshconnect-react-native-example",
-  "version": "2.5.0",
+  "version": "2.4.6",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshconnect-react-native-example",
-  "version": "2.4.5",
+  "version": "2.5.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.5",
+  "version": "2.5.0",
   "name": "@meshconnect/react-native-link-sdk",
   "description": "Mesh Connect React Native SDK.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.0",
+  "version": "2.4.6",
   "name": "@meshconnect/react-native-link-sdk",
   "description": "Mesh Connect React Native SDK.",
   "license": "MIT",

--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         domStorageEnabled={true}
         injectedJavaScript="
     window.meshSdkPlatform='reactNative';
-    window.meshSdkVersion='2.5.0';
+    window.meshSdkVersion='2.4.6';
   "
         javaScriptCanOpenWindowsAutomatically={true}
         javaScriptEnabled={true}

--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         domStorageEnabled={true}
         injectedJavaScript="
     window.meshSdkPlatform='reactNative';
-    window.meshSdkVersion='2.4.5';
+    window.meshSdkVersion='2.5.0';
   "
         javaScriptCanOpenWindowsAutomatically={true}
         javaScriptEnabled={true}

--- a/src/__tests__/language.test.ts
+++ b/src/__tests__/language.test.ts
@@ -1,5 +1,5 @@
 import { NativeModules, Platform } from 'react-native';
-import { getSystemLanguage } from '../utils/language';
+import { getSystemLanguage, resolveLanguage } from '../utils/language';
 
 describe('getSystemLanguage', () => {
   const originalOS = Platform.OS;
@@ -65,5 +65,43 @@ describe('getSystemLanguage', () => {
     });
 
     expect(getSystemLanguage()).toBeUndefined();
+  });
+});
+
+describe('resolveLanguage', () => {
+  const originalOS = Platform.OS;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (Platform as { OS: string }).OS = originalOS;
+    delete (NativeModules as Record<string, unknown>).SettingsManager;
+    delete (NativeModules as Record<string, unknown>).I18nManager;
+  });
+
+  test('passes a concrete tag through unchanged', () => {
+    expect(resolveLanguage('en-US')).toBe('en-US');
+  });
+
+  test('returns undefined when no language is set', () => {
+    expect(resolveLanguage(undefined)).toBeUndefined();
+  });
+
+  test('expands "system" to the device locale', () => {
+    (Platform as { OS: string }).OS = 'android';
+    (NativeModules as Record<string, unknown>).I18nManager = {
+      localeIdentifier: 'fr_FR',
+    };
+
+    expect(resolveLanguage('system')).toBe('fr-FR');
+  });
+
+  test('falls back to "en" when "system" cannot be resolved', () => {
+    (Platform as { OS: string }).OS = 'android';
+    (NativeModules as Record<string, unknown>).I18nManager = {};
+    jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => {
+      throw new Error('Intl unavailable');
+    });
+
+    expect(resolveLanguage('system')).toBe('en');
   });
 });

--- a/src/__tests__/language.test.ts
+++ b/src/__tests__/language.test.ts
@@ -1,0 +1,69 @@
+import { NativeModules, Platform } from 'react-native';
+import { getSystemLanguage } from '../utils/language';
+
+describe('getSystemLanguage', () => {
+  const originalOS = Platform.OS;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (Platform as { OS: string }).OS = originalOS;
+    delete (NativeModules as Record<string, unknown>).SettingsManager;
+    delete (NativeModules as Record<string, unknown>).I18nManager;
+  });
+
+  test('returns the iOS preferred language from AppleLanguages', () => {
+    (Platform as { OS: string }).OS = 'ios';
+    (NativeModules as Record<string, unknown>).SettingsManager = {
+      settings: { AppleLanguages: ['fr-FR'], AppleLocale: 'en_US' },
+    };
+
+    expect(getSystemLanguage()).toBe('fr-FR');
+  });
+
+  test('falls back to the iOS AppleLocale (underscores normalised) when no AppleLanguages', () => {
+    (Platform as { OS: string }).OS = 'ios';
+    (NativeModules as Record<string, unknown>).SettingsManager = {
+      settings: { AppleLocale: 'de_DE' },
+    };
+
+    expect(getSystemLanguage()).toBe('de-DE');
+  });
+
+  test('returns the Android locale (underscores normalised)', () => {
+    (Platform as { OS: string }).OS = 'android';
+    (NativeModules as Record<string, unknown>).I18nManager = {
+      localeIdentifier: 'es_ES',
+    };
+
+    expect(getSystemLanguage()).toBe('es-ES');
+  });
+
+  test('strips Unicode extension subtags from the locale', () => {
+    (Platform as { OS: string }).OS = 'android';
+    (NativeModules as Record<string, unknown>).I18nManager = {
+      localeIdentifier: 'th_TH-u-ca-buddhist',
+    };
+
+    expect(getSystemLanguage()).toBe('th-TH');
+  });
+
+  test('falls back to Intl when native modules report nothing', () => {
+    (Platform as { OS: string }).OS = 'android';
+    (NativeModules as Record<string, unknown>).I18nManager = {};
+    jest.spyOn(Intl, 'DateTimeFormat').mockReturnValue({
+      resolvedOptions: () => ({ locale: 'ja-JP' }),
+    } as unknown as Intl.DateTimeFormat);
+
+    expect(getSystemLanguage()).toBe('ja-JP');
+  });
+
+  test('returns undefined when neither native modules nor Intl resolve a locale', () => {
+    (Platform as { OS: string }).OS = 'android';
+    (NativeModules as Record<string, unknown>).I18nManager = {};
+    jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => {
+      throw new Error('Intl unavailable');
+    });
+
+    expect(getSystemLanguage()).toBeUndefined();
+  });
+});

--- a/src/__tests__/useSDKCallbacks.test.ts
+++ b/src/__tests__/useSDKCallbacks.test.ts
@@ -23,12 +23,13 @@ jest.mock('react-native/Libraries/Utilities/useColorScheme', () => {
 });
 
 jest.mock('../utils/language', () => ({
-  getSystemLanguage: jest.fn(),
+  ...jest.requireActual('../utils/language'),
+  resolveLanguage: jest.fn(),
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const mockedGetSystemLanguage = require('../utils/language')
-  .getSystemLanguage as jest.Mock;
+const mockedResolveLanguage = require('../utils/language')
+  .resolveLanguage as jest.Mock;
 
 describe('useSDKCallbacks', () => {
   const mockProps = {
@@ -305,16 +306,19 @@ describe('useSDKCallbacks: language behaviour', () => {
     jest.clearAllMocks();
   });
 
-  test('appends the given language tag as lng', () => {
+  test('appends the resolved language tag as lng', () => {
+    mockedResolveLanguage.mockReturnValue('en');
+
     const { result } = renderHook(() =>
       useSDKCallbacks({ linkToken: TOKEN_BASE_ONLY, settings: { language: 'en' } })
     );
 
+    expect(mockedResolveLanguage).toHaveBeenCalledWith('en');
     expect(result.current.linkUrl).toContain('lng=en');
   });
 
-  test('resolves "system" to the device language', () => {
-    mockedGetSystemLanguage.mockReturnValue('fr-FR');
+  test('passes the resolved system locale as lng, never the literal "system"', () => {
+    mockedResolveLanguage.mockReturnValue('fr-FR');
 
     const { result } = renderHook(() =>
       useSDKCallbacks({
@@ -323,26 +327,14 @@ describe('useSDKCallbacks: language behaviour', () => {
       })
     );
 
-    expect(mockedGetSystemLanguage).toHaveBeenCalled();
+    expect(mockedResolveLanguage).toHaveBeenCalledWith('system');
     expect(result.current.linkUrl).toContain('lng=fr-FR');
-    // The literal `system` must never reach the URL (the hosted UI needs a real tag)
     expect(result.current.linkUrl).not.toContain('lng=system');
   });
 
-  test('falls back to en when "system" cannot be resolved', () => {
-    mockedGetSystemLanguage.mockReturnValue(undefined);
+  test('does not append lng when the language resolves to undefined', () => {
+    mockedResolveLanguage.mockReturnValue(undefined);
 
-    const { result } = renderHook(() =>
-      useSDKCallbacks({
-        linkToken: TOKEN_BASE_ONLY,
-        settings: { language: 'system' },
-      })
-    );
-
-    expect(result.current.linkUrl).toContain('lng=en');
-  });
-
-  test('does not append lng when no language is set', () => {
     const { result } = renderHook(() =>
       useSDKCallbacks({ linkToken: TOKEN_BASE_ONLY })
     );

--- a/src/__tests__/useSDKCallbacks.test.ts
+++ b/src/__tests__/useSDKCallbacks.test.ts
@@ -22,6 +22,14 @@ jest.mock('react-native/Libraries/Utilities/useColorScheme', () => {
   };
 });
 
+jest.mock('../utils/language', () => ({
+  getSystemLanguage: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const mockedGetSystemLanguage = require('../utils/language')
+  .getSystemLanguage as jest.Mock;
+
 describe('useSDKCallbacks', () => {
   const mockProps = {
     linkToken: 'c29tZVZhbGlkTGlua1Rva2Vu',
@@ -289,5 +297,56 @@ describe('useSDKCallbacks – theme behaviour', () => {
     // No theme in token and no settings.theme → darkTheme defaults to false
     expect(result.current.darkTheme).toBe(false);
     expect(result.current.linkUrl).not.toContain('th=');
+  });
+});
+
+describe('useSDKCallbacks: language behaviour', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('appends the given language tag as lng', () => {
+    const { result } = renderHook(() =>
+      useSDKCallbacks({ linkToken: TOKEN_BASE_ONLY, settings: { language: 'en' } })
+    );
+
+    expect(result.current.linkUrl).toContain('lng=en');
+  });
+
+  test('resolves "system" to the device language', () => {
+    mockedGetSystemLanguage.mockReturnValue('fr-FR');
+
+    const { result } = renderHook(() =>
+      useSDKCallbacks({
+        linkToken: TOKEN_BASE_ONLY,
+        settings: { language: 'system' },
+      })
+    );
+
+    expect(mockedGetSystemLanguage).toHaveBeenCalled();
+    expect(result.current.linkUrl).toContain('lng=fr-FR');
+    // The literal `system` must never reach the URL (the hosted UI needs a real tag)
+    expect(result.current.linkUrl).not.toContain('lng=system');
+  });
+
+  test('falls back to en when "system" cannot be resolved', () => {
+    mockedGetSystemLanguage.mockReturnValue(undefined);
+
+    const { result } = renderHook(() =>
+      useSDKCallbacks({
+        linkToken: TOKEN_BASE_ONLY,
+        settings: { language: 'system' },
+      })
+    );
+
+    expect(result.current.linkUrl).toContain('lng=en');
+  });
+
+  test('does not append lng when no language is set', () => {
+    const { result } = renderHook(() =>
+      useSDKCallbacks({ linkToken: TOKEN_BASE_ONLY })
+    );
+
+    expect(result.current.linkUrl).not.toContain('lng=');
   });
 });

--- a/src/hooks/useSDKCallbacks.ts
+++ b/src/hooks/useSDKCallbacks.ts
@@ -8,7 +8,7 @@ import {
   isValidUrl,
   addURLParam,
   extractThemeFromToken,
-  getSystemLanguage,
+  resolveLanguage,
 } from '../utils';
 import { sdkSpecs } from '../utils/sdkConfig';
 import {
@@ -44,12 +44,8 @@ const useSDKCallbacks = (props: LinkConfiguration) => {
         }
 
         // Add the `language` to the URL as a `lng` query parameter.
-        // `'system'` expands to the device locale (mirrors the web SDK),
-        // and falls back to English when the locale cannot be determined.
-        let settingsLanguage = props.settings?.language;
-        if (settingsLanguage === 'system') {
-          settingsLanguage = getSystemLanguage() || 'en';
-        }
+        // `'system'` resolves to the device locale (see resolveLanguage).
+        const settingsLanguage = resolveLanguage(props.settings?.language);
         if (settingsLanguage) {
           decodedUrl = addURLParam(decodedUrl, 'lng', settingsLanguage);
         }

--- a/src/hooks/useSDKCallbacks.ts
+++ b/src/hooks/useSDKCallbacks.ts
@@ -8,6 +8,7 @@ import {
   isValidUrl,
   addURLParam,
   extractThemeFromToken,
+  getSystemLanguage,
 } from '../utils';
 import { sdkSpecs } from '../utils/sdkConfig';
 import {
@@ -42,8 +43,13 @@ const useSDKCallbacks = (props: LinkConfiguration) => {
           decodedUrl = addURLParam(decodedUrl, 'th', settingsTheme);
         }
 
-        // Add the `language` to the URL as a `lng` query parameter
-        const settingsLanguage = props.settings?.language;
+        // Add the `language` to the URL as a `lng` query parameter.
+        // `'system'` expands to the device locale (mirrors the web SDK),
+        // and falls back to English when the locale cannot be determined.
+        let settingsLanguage = props.settings?.language;
+        if (settingsLanguage === 'system') {
+          settingsLanguage = getSystemLanguage() || 'en';
+        }
         if (settingsLanguage) {
           decodedUrl = addURLParam(decodedUrl, 'lng', settingsLanguage);
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -330,6 +330,10 @@ export type LinkTheme = 'light' | 'dark' | 'system';
 
 export interface LinkSettings {
   accessTokens?: IntegrationAccessToken[];
+  /**
+   * Language for the Link UI as a BCP-47 tag (e.g. `'en'`, `'en-US'`).
+   * Use `'system'` to follow the device's current language.
+   */
   language?: string;
   displayFiatCurrency?: string;
   /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './isUrl';
 export * from './urlHelpers';
 export * from './styleHelpers';
 export * from './theme';
+export * from './language';

--- a/src/utils/language.ts
+++ b/src/utils/language.ts
@@ -1,0 +1,51 @@
+import { NativeModules, Platform } from 'react-native';
+
+/**
+ * Normalises a raw platform locale into a plain BCP-47 tag:
+ *  - native identifiers use underscores (`en_US`), converted to hyphens;
+ *  - Unicode extension subtags (e.g. `-u-ca-buddhist`) are stripped, since
+ *    the hosted Link UI expects the same shape the web SDK sends via
+ *    `navigator.language`, which never carries them.
+ */
+function normalizeLocale(tag: string): string {
+  return tag.replace(/_/g, '-').replace(/-u-.*$/i, '');
+}
+
+/**
+ * Resolves the device's current language as a BCP-47 tag (e.g. `en-US`).
+ * This is the React Native equivalent of the web SDK's `navigator.language`,
+ * used to expand `settings.language: 'system'` into a concrete tag before it
+ * is sent to the hosted Link UI (the UI expects a real tag, not `'system'`).
+ *
+ * The native settings modules are read first because they reflect the real
+ * device language on every JS engine. `Intl` is only a fallback: on Hermes
+ * builds without full ICU (and on JSC) it can report a fixed `en-US` rather
+ * than the device locale, so trusting it first would silently force English
+ * for non-English users.
+ *
+ * Returns `undefined` when no locale can be determined so callers can apply
+ * their own fallback.
+ */
+export function getSystemLanguage(): string | undefined {
+  const { SettingsManager, I18nManager } = NativeModules;
+  const nativeLocale =
+    Platform.OS === 'ios'
+      ? SettingsManager?.settings?.AppleLanguages?.[0] ||
+        SettingsManager?.settings?.AppleLocale
+      : I18nManager?.localeIdentifier;
+
+  if (nativeLocale) {
+    return normalizeLocale(nativeLocale);
+  }
+
+  try {
+    const intlLocale = Intl.DateTimeFormat().resolvedOptions().locale;
+    if (intlLocale) {
+      return normalizeLocale(intlLocale);
+    }
+  } catch {
+    // Intl is not available on this engine; nothing more to try.
+  }
+
+  return undefined;
+}

--- a/src/utils/language.ts
+++ b/src/utils/language.ts
@@ -49,3 +49,18 @@ export function getSystemLanguage(): string | undefined {
 
   return undefined;
 }
+
+/**
+ * Resolves a `settings.language` value into the concrete tag to send as `lng`.
+ * `'system'` expands to the device locale (falling back to `'en'` when it
+ * cannot be determined); any other value is passed through unchanged, and
+ * `undefined` stays `undefined` so no `lng` param is added.
+ */
+export function resolveLanguage(
+  language: string | undefined
+): string | undefined {
+  if (language === 'system') {
+    return getSystemLanguage() || 'en';
+  }
+  return language;
+}


### PR DESCRIPTION
## Overview

[PRG-2297](https://meshconnectapi.atlassian.net/browse/PRG-2297) - React Native SDK: add support for 'system' language

`settings.language` now accepts `'system'`. It resolves the device locale (native settings modules first, `Intl` as a fallback), normalises it to a plain BCP-47 tag, and sends that as the `lng` query param, so the literal `system` never reaches the hosted Link UI. This mirrors the web SDK's `addLanguage` behaviour. Falls back to `en` when no locale can be determined. Bumps the SDK to 2.4.6.

### 🎨 Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (existing functionality affected)
- [ ] Maintenance (tests, build, tooling, performance)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

### 👌 Checklist

- [x] I've performed a self-review, and it meets ticket criteria.
- [x] I've commented hard-to-understand areas.
- [X] I've updated documentation where necessary.
- [x] I've added tests that prove the fix or feature works.
- [X] I've tested the changes on a physical device or emulator.


[PRG-2297]: https://meshconnectapi.atlassian.net/browse/PRG-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


### Screenshots (example with German locale)
<img width="417" height="852" alt="image" src="https://github.com/user-attachments/assets/6813bfd2-5ba1-4de1-bfa5-3657c5468f50" />

<img width="417" height="852" alt="image" src="https://github.com/user-attachments/assets/81078307-11f6-432b-acb3-fe7ab43ea103" />


<img width="417" height="852" alt="image" src="https://github.com/user-attachments/assets/1fdf0035-536c-4ee4-812f-c2c44414de70" />

