### PR TITLE
ONC-447 restore Android wallet deep links dropped by the popup gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the Mesh Connect React Native SDK are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.4.7
+
+### Fixed
+
+- Wallet deep links now open on Android again. `setSupportMultipleWindows={false}` (added in 2.4.3) turned a `target="_blank"` click into a same-frame navigation, which react-native-webview gates behind `Linking.canOpenURL` — package-visibility filtered on Android 11+, so a wallet's custom scheme was dropped with only a console warning unless the integrator declared it in their manifest `<queries>`. Popups are routed to `onOpenWindow` again, where the SDK launches them itself.
+
+### Changed
+
+- `onOpenWindow` now opens app schemes (e.g. `dfw://`, `metamask://`) in addition to `https`. Schemes that can execute or reach local state — `javascript:`, `data:`, `file:`, `content:`, `intent:`, `android-app:`, `about:`, `blob:` — are still ignored, as is plain `http:`.
+- A custom scheme reaching `onShouldStartLoadWithRequest` is now launched instead of silently blocked, so a scheme listed in `WHITELISTED_ORIGINS` (e.g. `robinhood://`) is no longer a dead end.
+
 ## 2.4.6
 
 ### Added

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshconnect-react-native-example",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.6",
+  "version": "2.4.7",
   "name": "@meshconnect/react-native-link-sdk",
   "description": "Mesh Connect React Native SDK.",
   "license": "MIT",

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -156,7 +156,10 @@ describe('LinkConnect Component', () => {
     });
   });
 
-  it('onOpenWindow ignores dangerous / non-https schemes', async () => {
+  // PRG-3183 allowed https only here, which also excluded custom schemes — at the
+  // time nothing needed one. Wallet deep links do (ONC-447), so the rule is now
+  // https plus app schemes, minus anything that can execute or read local state.
+  it('onOpenWindow ignores dangerous / insecure schemes', async () => {
     const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
     (Linking.openURL as jest.Mock).mockClear();
     await waitFor(() => {
@@ -164,12 +167,75 @@ describe('LinkConnect Component', () => {
       [
         'javascript:alert(1)',
         'data:text/html,<script>alert(1)</script>',
+        'file:///etc/passwd',
+        'content://com.example.provider/secrets',
+        'intent://scan/#Intent;scheme=zxing;end',
+        'blob:https://example.com/uuid',
         'http://insecure.example.com',
-        'meshapp://deeplink',
+        undefined,
+        '',
       ].forEach((targetUrl) => {
         webview.props.onOpenWindow({ nativeEvent: { targetUrl } });
       });
       expect(Linking.openURL).not.toHaveBeenCalled();
+    });
+  });
+
+  // ONC-447: the Android popup path for a wallet deep link. Dropping these is
+  // what left "Open <wallet>" doing nothing in react-native hosts.
+  it.each([
+    'dfw://wc?uri=wc%3Atopic%402',
+    'metamask://wc?uri=wc%3Atopic%402',
+    'robinhood://wc?uri=wc%3Atopic%402',
+  ])('onOpenWindow launches the wallet deep link %s', async (targetUrl) => {
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    (Linking.openURL as jest.Mock).mockClear();
+    await waitFor(() => {
+      getByTestId('webview').props.onOpenWindow({ nativeEvent: { targetUrl } });
+      expect(Linking.openURL).toHaveBeenCalledWith(targetUrl);
+    });
+  });
+
+  // Same-frame twin of the above: reachable when the scheme is whitelisted, which
+  // previously fell through to `startsWith('http')` and was dropped silently.
+  it('onShouldStartLoadWithRequest launches a wallet deep link and returns false', async () => {
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    (Linking.openURL as jest.Mock).mockClear();
+    await waitFor(() => {
+      const result = getByTestId('webview').props.onShouldStartLoadWithRequest({
+        url: 'dfw://wc?uri=wc%3Atopic%402',
+      });
+      expect(Linking.openURL).toHaveBeenCalledWith('dfw://wc?uri=wc%3Atopic%402');
+      expect(result).toBe(false);
+    });
+  });
+
+  // PRG-3107 required Binance auth to reach a handler the SDK controls. With
+  // multiple windows back at the library default, Android popups arrive here
+  // instead of in onShouldStartLoadWithRequest — this pins that it still opens.
+  it('onOpenWindow opens Binance app auth externally (PRG-3107 via the popup path)', async () => {
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    (Linking.openURL as jest.Mock).mockClear();
+    await waitFor(() => {
+      getByTestId('webview').props.onOpenWindow({
+        nativeEvent: {
+          targetUrl: 'https://app.binance.com/en/oauth/authorize?client_id=mesh',
+        },
+      });
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        'https://app.binance.com/en/oauth/authorize?client_id=mesh'
+      );
+    });
+  });
+
+  it('keeps Android popups routed to a handler the SDK controls', async () => {
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    await waitFor(() => {
+      const webview = getByTestId('webview');
+      // false would make Android target="_blank" a same-frame navigation, which
+      // react-native-webview gates behind Linking.canOpenURL before our handler.
+      expect(webview.props.setSupportMultipleWindows).toBe(true);
+      expect(typeof webview.props.onOpenWindow).toBe('function');
     });
   });
 

--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         domStorageEnabled={true}
         injectedJavaScript="
     window.meshSdkPlatform='reactNative';
-    window.meshSdkVersion='2.4.6';
+    window.meshSdkVersion='2.4.7';
   "
         javaScriptCanOpenWindowsAutomatically={true}
         javaScriptEnabled={true}
@@ -97,7 +97,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
             "robinhood://",
           ]
         }
-        setSupportMultipleWindows={false}
+        setSupportMultipleWindows={true}
         source={
           {
             "uri": "https://web.getfront.com/b2b-iframe/test-account-random/broker-connect/catalog1?platform=reactNative",

--- a/src/__tests__/appLaunchScheme.test.ts
+++ b/src/__tests__/appLaunchScheme.test.ts
@@ -47,7 +47,12 @@ describe('isAppLaunchScheme', () => {
     }
   );
 
-  it('ignores surrounding whitespace', () => {
-    expect(isAppLaunchScheme('  dfw://wc  ')).toBe(true);
-  });
+  // The caller launches the URL exactly as given, so accepting a padded URL here
+  // would hand the whitespace straight to openURL, which fails on it.
+  it.each(['  dfw://wc', 'dfw://wc  ', ' dfw://wc ', 'dfw://wc?x=a b', 'dfw://wc\n'])(
+    'rejects the URL %s, which carries raw whitespace',
+    (url) => {
+      expect(isAppLaunchScheme(url)).toBe(false);
+    }
+  );
 });

--- a/src/__tests__/appLaunchScheme.test.ts
+++ b/src/__tests__/appLaunchScheme.test.ts
@@ -1,0 +1,53 @@
+import { isAppLaunchScheme } from '../utils/appLaunchScheme';
+
+describe('isAppLaunchScheme', () => {
+  // Wallet deep links the Link WebView hands off (ONC-447). `Linking.openURL`
+  // launches these via startActivity, which no manifest declaration gates.
+  it.each([
+    'dfw://wc?uri=wc%3Atopic%402',
+    'metamask://wc?uri=wc%3Atopic%402',
+    'robinhood://wc',
+    'bnc://app.binance.com',
+    'cryptowallet://wc',
+    'trust://wc',
+    'DFW://WC',
+  ])('accepts the app scheme %s', (url) => {
+    expect(isAppLaunchScheme(url)).toBe(true);
+  });
+
+  // http(s) is not an app launch: it loads in the WebView, or is routed by
+  // isExternallyOpenedOrigin when its origin must leave it.
+  it.each(['https://app.binance.com/auth', 'http://example.com', 'HTTPS://X.COM'])(
+    'rejects the web URL %s',
+    (url) => {
+      expect(isAppLaunchScheme(url)).toBe(false);
+    }
+  );
+
+  // These execute, or reach local storage / an arbitrary component, so they must
+  // never be handed to the OS from web content.
+  it.each([
+    'javascript:alert(1)',
+    'JavaScript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'file:///etc/passwd',
+    'content://com.example.provider/secrets',
+    'intent://scan/#Intent;scheme=zxing;end',
+    'android-app://com.example',
+    'about:blank',
+    'blob:https://example.com/uuid',
+  ])('rejects the dangerous scheme %s', (url) => {
+    expect(isAppLaunchScheme(url)).toBe(false);
+  });
+
+  it.each([undefined, null, '', '   ', 'not-a-url', '//protocol-relative', '1invalid://x'])(
+    'rejects the malformed input %s',
+    (url) => {
+      expect(isAppLaunchScheme(url)).toBe(false);
+    }
+  );
+
+  it('ignores surrounding whitespace', () => {
+    expect(isAppLaunchScheme('  dfw://wc  ')).toBe(true);
+  });
+});

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -9,12 +9,31 @@ import { SDKViewContainer } from './SDKViewContainer';
 import type { LinkConfiguration } from '../';
 import { useSDKCallbacks } from '../hooks/useSDKCallbacks';
 import { sdkSpecs } from '../utils/sdkConfig';
-import { isExternallyOpenedOrigin } from '../utils';
+import { isAppLaunchScheme, isExternallyOpenedOrigin } from '../utils';
 import {
   DARK_THEME_COLOR_BOTTOM,
   LIGHT_THEME_COLOR_BOTTOM,
   WHITELISTED_ORIGINS,
 } from '../constant';
+
+/**
+ * Hand a URL to the OS — the external browser for https, the wallet app for a
+ * custom scheme.
+ *
+ * `openURL` is deliberate: it issues a view intent via `startActivity`, so unlike
+ * `canOpenURL` it is not subject to Android 11+ package-visibility filtering and
+ * resolves whenever the target app is installed. A rejection is unlikely for
+ * these URLs, but is caught so a failed open cannot surface as an unhandled
+ * promise rejection. Warn in dev only, to avoid noise in integrators'
+ * production builds.
+ */
+const openExternally = (url: string): void => {
+  void Linking.openURL(url).catch((err) => {
+    if (__DEV__) {
+      console.warn('Failed to open external URL', url, err);
+    }
+  });
+};
 
 const LoadingComponentWebview = ({ darkTheme }: { darkTheme: boolean }) => {
   return (
@@ -117,44 +136,40 @@ export const LinkConnect = (props: LinkConfiguration) => {
           injectedJavaScript={injectedScript}
           {...whiteListProps}
           onNavigationStateChange={handleNavState}
-          setSupportMultipleWindows={false}
+          // Android popup routing. PRG-3107 set this false so Binance app auth
+          // reached a handler the SDK controls; at the time onOpenWindow did not
+          // exist, so onShouldStartLoadWithRequest was the only one. It is back to
+          // the library default because false has a side effect: an Android
+          // `target="_blank"` click becomes a same-frame navigation, and
+          // react-native-webview's own wrapper reaches that before our handler,
+          // gating every non-whitelisted URL behind `Linking.canOpenURL` — which
+          // is package-visibility filtered on Android 11+ and answers false for
+          // any scheme the integrator's manifest does not name in `<queries>`.
+          // Wallet deep links were dropped with only a console warning (ONC-447).
+          // With multiple windows enabled those clicks arrive at onOpenWindow,
+          // which opens both https handoffs and wallet schemes — so PRG-3107's
+          // Binance behaviour holds, via the sibling handler.
+          setSupportMultipleWindows={true}
           // iOS blocks a gestureless window.open (e.g. link-v2's Coinbase
           // deposit handoff fires it after an async fetch, outside the tap).
           // Without this, WebKit never calls the popup delegate, so
           // onOpenWindow below never fires and the deposit dead-ends.
           javaScriptCanOpenWindowsAutomatically={true}
           onShouldStartLoadWithRequest={(req) => {
-            if (isExternallyOpenedOrigin(req.url)) {
-              // These origins open in the browser or a native app (e.g. the
-              // Binance app via the bnc:// deep link), so a rejection is
-              // unlikely; catch anyway so a failed open can't surface as an
-              // unhandled promise rejection. Warn in dev only, to avoid noise
-              // in integrators' production builds.
-              void Linking.openURL(req.url).catch((err) => {
-                if (__DEV__) {
-                  console.warn('Failed to open external URL', req.url, err);
-                }
-              });
+            if (isExternallyOpenedOrigin(req.url) || isAppLaunchScheme(req.url)) {
+              openExternally(req.url);
               return false;
             }
             return req.url.startsWith('http');
           }}
           onOpenWindow={({ nativeEvent }) => {
-            // link-v2 hands off OAuth/onramp via window.open('_blank') on a
-            // catalog tap. On iOS the WebView surfaces that here instead of
-            // navigating, so without forwarding it the popup is dropped and the
-            // flow dead-ends. Open it in the external browser, same
-            // as the in-page "Re-open" fallback and the Android
-            // onShouldStartLoadWithRequest path. Require https so a blank,
-            // opaque, or non-https (javascript:/data:/custom-scheme) target is
-            // ignored.
+            // Every `target="_blank"` / window.open target lands here: link-v2's
+            // OAuth and on-ramp handoffs (https) and its wallet deep links
+            // (custom scheme). Both must leave the WebView; anything that could
+            // execute or read local state is rejected by isAppLaunchScheme.
             const { targetUrl } = nativeEvent;
-            if (targetUrl?.startsWith('https://')) {
-              void Linking.openURL(targetUrl).catch((err) => {
-                if (__DEV__) {
-                  console.warn('Failed to open external URL', targetUrl, err);
-                }
-              });
+            if (targetUrl?.startsWith('https://') || isAppLaunchScheme(targetUrl)) {
+              openExternally(targetUrl);
             }
           }}
           domStorageEnabled={true}

--- a/src/utils/appLaunchScheme.ts
+++ b/src/utils/appLaunchScheme.ts
@@ -1,0 +1,47 @@
+// Schemes that must never be handed to the OS from web content. `javascript:`
+// and `data:` execute in whatever context receives them; `file:` and `content:`
+// reach local storage; `intent:` lets a crafted URL address an arbitrary
+// component with arbitrary extras; `about:` is inert but meaningless to launch.
+const BLOCKED_SCHEMES = new Set([
+  'javascript',
+  'data',
+  'file',
+  'content',
+  'intent',
+  'android-app',
+  'about',
+  'blob',
+]);
+
+const SCHEME_PATTERN = /^([a-z][a-z0-9+.-]*):/i;
+
+/**
+ * True when `url` should be launched as an app deep link — a wallet's custom
+ * scheme such as `dfw://` or `metamask://`.
+ *
+ * Why the SDK has to launch these itself: react-native-webview asks
+ * `Linking.canOpenURL` before any of our own handlers see a URL outside
+ * `originWhitelist`, and on Android 11+ that call is package-visibility filtered
+ * — it answers `false` for every scheme the *integrator's* manifest does not
+ * name in `<queries>`, and the URL is then dropped with only a console warning.
+ * `Linking.openURL` has no such restriction: it issues `startActivity` with a
+ * view intent, which resolves whenever the wallet is installed. So the scheme is
+ * launched directly rather than probed first.
+ *
+ * `http(s)` is excluded: those load in the WebView, or are routed by
+ * `isExternallyOpenedOrigin` when they belong to an origin that must leave it.
+ */
+export const isAppLaunchScheme = (url: string | undefined | null): boolean => {
+  if (!url) {
+    return false;
+  }
+  const match = SCHEME_PATTERN.exec(url.trim());
+  if (!match) {
+    return false;
+  }
+  const scheme = match[1].toLowerCase();
+  if (scheme === 'http' || scheme === 'https') {
+    return false;
+  }
+  return !BLOCKED_SCHEMES.has(scheme);
+};

--- a/src/utils/appLaunchScheme.ts
+++ b/src/utils/appLaunchScheme.ts
@@ -14,6 +14,7 @@ const BLOCKED_SCHEMES = new Set([
 ]);
 
 const SCHEME_PATTERN = /^([a-z][a-z0-9+.-]*):/i;
+const WHITESPACE_PATTERN = /\s/;
 
 /**
  * True when `url` should be launched as an app deep link — a wallet's custom
@@ -30,12 +31,19 @@ const SCHEME_PATTERN = /^([a-z][a-z0-9+.-]*):/i;
  *
  * `http(s)` is excluded: those load in the WebView, or are routed by
  * `isExternallyOpenedOrigin` when they belong to an origin that must leave it.
+ *
+ * Matched strictly, with no normalising: the caller launches the URL exactly as
+ * given, so anything accepted here must be launchable as-is. A URL carrying raw
+ * whitespace is rejected rather than accepted and then handed to `openURL`,
+ * which fails on it — a valid URL percent-encodes whitespace, and a WebView
+ * navigation target is already normalised, so this only rejects input that was
+ * malformed to begin with.
  */
 export const isAppLaunchScheme = (url: string | undefined | null): boolean => {
-  if (!url) {
+  if (!url || WHITESPACE_PATTERN.test(url)) {
     return false;
   }
-  const match = SCHEME_PATTERN.exec(url.trim());
+  const match = SCHEME_PATTERN.exec(url);
   if (!match) {
     return false;
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 export * from './base64';
+export * from './appLaunchScheme';
 export * from './externallyOpenedOrigin';
 export * from './isUrl';
 export * from './urlHelpers';


### PR DESCRIPTION
## What broke

`setSupportMultipleWindows={false}` — added in **2.4.3 (PRG-3107)** so Binance app auth would reach a handler the SDK controls — has a side effect on Android: a `target="_blank"` click stops being a popup and becomes a same-frame navigation. react-native-webview's own `onShouldStartLoadWithRequest` wrapper reaches that before ours and gates every URL outside `originWhitelist` behind `Linking.canOpenURL`:

```js
// react-native-webview 13.16.1 — WebViewShared.tsx:53-65
if (!passesWhitelist(compileWhitelist(originWhitelist), url)) {
  Linking.canOpenURL(url).then((supported) => {
    if (supported) return Linking.openURL(url);
    console.warn(`Can't open url: ${url}`);   // ← wallet deep link dies here
  });
  shouldStart = false;
}
```

`canOpenURL` is package-visibility filtered on Android 11+: it answers `false` for any scheme the **integrator's** manifest does not name in `<queries>`. Link fires wallet deep links through exactly this path, so "Open \<wallet\>" did nothing and no error surfaced anywhere.

Measured: **40 Crypto.com Onchain pairings over 7 days from an Android react-native host, 0 reaching the wallet** (`link.wallet.deeplink.attempted`, `linkType: native`). The same wallet works on mobile web and on iOS.

**2.3.0 was unaffected.** With multiple windows at the library default, the click became a popup whose URL left through a framework view intent — `startActivity`, which is not visibility-filtered. That's why a test on 2.3.0 passes and CDC's 2.4.5 fails; the SDK version is the discriminator.

## The fix

**Multiple windows back to the library default.** PRG-3107's requirement is that the URL reach a handler we control. Since **2.4.4 (PRG-3183)** there are two, and `onOpenWindow` covers both platforms — so Android popups arrive there instead, and Binance keeps opening externally via the sibling handler. `setSupportMultipleWindows` is Android-only, so PRG-3183's iOS path is untouched. Pinned with a regression test that names PRG-3107.

**Launch, don't probe.** `Linking.openURL` issues `startActivity` with a view intent and resolves whenever the app is installed — no manifest declaration, no visibility filter. `canOpenURL` is never consulted.

**`onOpenWindow` opens app schemes as well as https.** PRG-3183 restricted it to https, which also excluded custom schemes — nothing needed one then. New `isAppLaunchScheme` allows a wallet scheme and rejects anything that can execute or reach local state (`javascript:`, `data:`, `file:`, `content:`, `intent:`, `android-app:`, `about:`, `blob:`), plus plain `http:`.

**A custom scheme reaching `onShouldStartLoadWithRequest` is now launched** instead of silently returning `false`, so a scheme listed in `WHITELISTED_ORIGINS` (`robinhood://`) is no longer a dead end.

## Behaviour review

| Case | Before | After |
|---|---|---|
| Binance app auth, same-frame | opens externally | unchanged |
| Binance app auth, Android popup | via `onShouldStartLoadWithRequest` | via `onOpenWindow` — still opens |
| iOS OAuth/onramp popup (PRG-3183) | opens externally | unchanged |
| Wallet deep link, Android | **silently dropped** | opens |
| `javascript:` / `data:` / `file:` / `http:` popup | ignored | unchanged |
| `meshapp://` popup | ignored | now opens — see below |
| **Whitelisted https popup on Android** (`*.okx.com`, `*.gemini.com`, `*.robinhood.com`, `applink.robinhood.com`, `*.meshconnect.com`, `*.getfront.com`) | loaded **in-frame** | **opens in the external browser** |
| Non-whitelisted https popup on Android | external browser (via the wrapper's own `canOpenURL` branch) | unchanged |
| Iframe navigation (hCaptcha, Stripe 3DS) | in-frame | unchanged — `onOpenWindow` fires only for `window.open` / `target="_blank"` |

Two intentional changes, both stated rather than left implicit:

1. A test asserting `onOpenWindow` ignores `meshapp://` encoded PRG-3183's https-only rule. Wallet deep links need custom schemes, so that test is updated with the reason in a comment; the dangerous-scheme denylist holds the security line now.
2. **Whitelisted https popups now leave the WebView on Android.** With popups re-enabled, a whitelisted-origin `target="_blank"` https target reaches `onOpenWindow` instead of collapsing into a same-frame navigation, so it opens in the browser. This is intended: iOS has routed every https popup to the browser since PRG-3183 and Android now matches, link-v2 opens OAuth with `noopener,noreferrer` and completes by **polling** (`oauthHandoff.ts:99`, `useOAuthOpenFlow` → `oauth-waiting` / `onramp-polling`) so no opener callback depends on the popup, and iframes are untouched. Pinned by `onOpenWindow opens the whitelisted https origin %s externally`.

**Still wanted before merge:** one device tap through a whitelisted-origin OAuth broker (Robinhood / OKX / Gemini) on Android. Not for the opener — for the return path: today's Android flow is a same-frame navigation that reloads Link afterwards (which is why `isOAuthInProgress` exists to suppress auto-reload), whereas now Link stays mounted and polls.

## Checks

`jest` 116 passed / 13 suites (incl. new `appLaunchScheme` unit tests and popup-path regression tests) · `tsc --noEmit` clean · `eslint` clean · `yarn build` + `check:build` verified · CHANGELOG + version → 2.4.7.

## Notes for the reviewer

- Ships alongside a link-v2 mitigation that routes gated hosts to the universal link, so CDC is unblocked **without** waiting on this release. This PR is the actual fix; that one is a stopgap.
- **Proposed follow-up, not in this PR:** have the injected script set `window.handleNativeLink = { canOpen: true }`. link-v2 already honours that flag, so a fixed SDK could declare its capability and retire the mitigation automatically instead of leaving react-native hosts on universal links forever. Happy to add it here if you'd prefer it in one change.

Linear: ONC-447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
