### PR TITLE
PRG-32 recover the Link WebView after a render-process death during OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Mesh Connect React Native SDK are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.4.8
+
+### Fixed
+
+- Android: the Link WebView now recovers instead of going blank when its render process is killed while the app is backgrounded during an external OAuth or deposit hand-off (e.g. Coinbase). It reloads automatically on return to the foreground.
+
 ## 2.4.7
 
 ### Fixed

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshconnect-react-native-example",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.7",
+  "version": "2.4.8",
   "name": "@meshconnect/react-native-link-sdk",
   "description": "Mesh Connect React Native SDK.",
   "license": "MIT",

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -35,6 +35,8 @@ describe('LinkConnect Component', () => {
   beforeEach(() => {
     mockReload.mockClear();
     jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
+    // Default to foreground; the backgrounded-recovery test overrides this.
+    (AppState as any).currentState = 'active';
   });
 
   afterEach(() => {
@@ -385,7 +387,7 @@ describe('LinkConnect Component', () => {
     });
   });
 
-  it('recovers a dead WebView on foreground return (AppState active)', async () => {
+  it('recovers a dead WebView on foreground return after a backgrounded renderer death', async () => {
     let appStateCb: ((s: string) => void) | undefined;
     jest
       .spyOn(AppState, 'addEventListener')
@@ -394,16 +396,18 @@ describe('LinkConnect Component', () => {
         return { remove: jest.fn() } as any;
       });
     const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
-    await waitFor(() => {
-      // Renderer dies -> immediate reload + a "rendererGone" flag is set.
-      getByTestId('webview').props.onRenderProcessGone();
-      expect(mockReload).toHaveBeenCalledTimes(1);
-    });
+    await waitFor(() => getByTestId('webview'));
+    // Renderer dies while backgrounded: no immediate reload (it would not
+    // take), just the rendererGone flag.
+    (AppState as any).currentState = 'background';
+    getByTestId('webview').props.onRenderProcessGone();
+    expect(mockReload).toHaveBeenCalledTimes(0);
     // Coming back to the foreground recovers the dead WebView.
+    (AppState as any).currentState = 'active';
     appStateCb?.('active');
-    expect(mockReload).toHaveBeenCalledTimes(2);
+    expect(mockReload).toHaveBeenCalledTimes(1);
     // Flag is cleared, so a later foreground does nothing.
     appStateCb?.('active');
-    expect(mockReload).toHaveBeenCalledTimes(2);
+    expect(mockReload).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -410,4 +410,22 @@ describe('LinkConnect Component', () => {
     appStateCb?.('active');
     expect(mockReload).toHaveBeenCalledTimes(1);
   });
+
+  it('does not reload again on a later foreground when the renderer died while active', async () => {
+    let appStateCb: ((s: string) => void) | undefined;
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((event: any, cb: any) => {
+        if (event === 'change') appStateCb = cb;
+        return { remove: jest.fn() } as any;
+      });
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    await waitFor(() => getByTestId('webview'));
+    // Died while foreground: immediate reload, and the flag must NOT be left set.
+    getByTestId('webview').props.onRenderProcessGone();
+    expect(mockReload).toHaveBeenCalledTimes(1);
+    // A later, unrelated foreground must not fire a spurious reload.
+    appStateCb?.('active');
+    expect(mockReload).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import React from 'react';
-import { Linking } from 'react-native';
+import { AppState, Linking } from 'react-native';
 import { render, waitFor } from '@testing-library/react-native';
 import { LinkConnect } from '../components/LinkConnect';
 
@@ -350,15 +350,18 @@ describe('LinkConnect Component', () => {
     });
   });
 
-  it('does not reload on onContentProcessDidTerminate when OAuth is in progress', async () => {
+  it('reloads on onContentProcessDidTerminate even during OAuth (dead renderer recovers)', async () => {
     const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
     await waitFor(() => {
       const webview = getByTestId('webview');
       webview.props.onMessage({
         nativeEvent: { data: JSON.stringify({ type: 'integrationOAuthStarted' }) },
       });
+      // A dead render process can't finish an OAuth, so it must recover
+      // regardless of isOAuthInProgress; the old behavior left a blank/stuck
+      // WebView.
       webview.props.onContentProcessDidTerminate();
-      expect(mockReload).not.toHaveBeenCalled();
+      expect(mockReload).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -370,7 +373,7 @@ describe('LinkConnect Component', () => {
     });
   });
 
-  it('does not reload on onRenderProcessGone when OAuth is in progress', async () => {
+  it('reloads on onRenderProcessGone even during OAuth (dead renderer recovers)', async () => {
     const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
     await waitFor(() => {
       const webview = getByTestId('webview');
@@ -378,7 +381,29 @@ describe('LinkConnect Component', () => {
         nativeEvent: { data: JSON.stringify({ type: 'integrationOAuthStarted' }) },
       });
       webview.props.onRenderProcessGone();
-      expect(mockReload).not.toHaveBeenCalled();
+      expect(mockReload).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('recovers a dead WebView on foreground return (AppState active)', async () => {
+    let appStateCb: ((s: string) => void) | undefined;
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((event: any, cb: any) => {
+        if (event === 'change') appStateCb = cb;
+        return { remove: jest.fn() } as any;
+      });
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    await waitFor(() => {
+      // Renderer dies -> immediate reload + a "rendererGone" flag is set.
+      getByTestId('webview').props.onRenderProcessGone();
+      expect(mockReload).toHaveBeenCalledTimes(1);
+    });
+    // Coming back to the foreground recovers the dead WebView.
+    appStateCb?.('active');
+    expect(mockReload).toHaveBeenCalledTimes(2);
+    // Flag is cleared, so a later foreground does nothing.
+    appStateCb?.('active');
+    expect(mockReload).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         domStorageEnabled={true}
         injectedJavaScript="
     window.meshSdkPlatform='reactNative';
-    window.meshSdkVersion='2.4.7';
+    window.meshSdkVersion='2.4.8';
   "
         javaScriptCanOpenWindowsAutomatically={true}
         javaScriptEnabled={true}

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -79,16 +79,35 @@ export const LinkConnect = (props: LinkConfiguration) => {
   // Recover a dead WebView on foreground return. If the render process was
   // killed while backgrounded (memory pressure during an external OAuth trip),
   // reload once when the user comes back so the flow isn't stuck on a blank
-  // WebView with the in-progress session silently lost.
+  // WebView with the in-progress session silently lost. Only clear the flag
+  // once a reload can actually run (ref mounted), so a not-yet-mounted WebView
+  // on the first foreground tick doesn't drop the recovery.
   useEffect(() => {
     const sub = AppState.addEventListener('change', state => {
-      if (state === 'active' && rendererGone.current) {
+      if (state === 'active' && rendererGone.current && webViewRef.current) {
         rendererGone.current = false;
-        webViewRef.current?.reload();
+        webViewRef.current.reload();
       }
     });
     return () => sub.remove();
   }, []);
+
+  // A dead render process can't complete an OAuth (the old isOAuthInProgress
+  // guard just stranded the flow on a blank WebView), so recover regardless.
+  // Foregrounded: reload now. Backgrounded: a reload issued now may not take,
+  // so flag it and let the AppState 'active' listener recover on return. We do
+  // not flag after a foreground reload, so an unrelated later foreground does
+  // not fire a spurious reload that would restart the session.
+  const recoverFromRendererDeath = () => {
+    if (AppState.currentState === 'active') {
+      if (!hasAutoReloaded.current) {
+        hasAutoReloaded.current = true;
+        webViewRef.current?.reload();
+      }
+    } else {
+      rendererGone.current = true;
+    }
+  };
 
   const injectedScript = useMemo(() => {
     let sdkTypeScript = `
@@ -222,24 +241,8 @@ export const LinkConnect = (props: LinkConfiguration) => {
               webViewRef.current?.reload();
             }
           }}
-          onContentProcessDidTerminate={() => {
-            // Renderer process died. Reload REGARDLESS of isOAuthInProgress: a
-            // dead renderer can't complete an OAuth, so the old guard just left
-            // a blank/stuck WebView. Mark it so AppState can also recover if
-            // we're backgrounded right now.
-            rendererGone.current = true;
-            if (!hasAutoReloaded.current) {
-              hasAutoReloaded.current = true;
-              webViewRef.current?.reload();
-            }
-          }}
-          onRenderProcessGone={() => {
-            rendererGone.current = true;
-            if (!hasAutoReloaded.current) {
-              hasAutoReloaded.current = true;
-              webViewRef.current?.reload();
-            }
-          }}
+          onContentProcessDidTerminate={recoverFromRendererDeath}
+          onRenderProcessGone={recoverFromRendererDeath}
         />
       )}
     </SDKWrapperComponent>

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -1,4 +1,5 @@
 import { AppState, Linking, View } from 'react-native';
+import type { AppStateStatus } from 'react-native';
 import { WebView } from 'react-native-webview';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -83,13 +84,29 @@ export const LinkConnect = (props: LinkConfiguration) => {
   // once a reload can actually run (ref mounted), so a not-yet-mounted WebView
   // on the first foreground tick doesn't drop the recovery.
   useEffect(() => {
-    const sub = AppState.addEventListener('change', state => {
+    const handler = (state: AppStateStatus) => {
       if (state === 'active' && rendererGone.current && webViewRef.current) {
         rendererGone.current = false;
         webViewRef.current.reload();
       }
-    });
-    return () => sub.remove();
+    };
+    const sub = AppState.addEventListener('change', handler);
+    // RN >=0.65 returns a subscription with remove(); older RN (the peer dep
+    // allows >=0.60) returns void and needs the static removeEventListener.
+    return () => {
+      if (typeof sub?.remove === 'function') {
+        sub.remove();
+      } else {
+        (
+          AppState as unknown as {
+            removeEventListener?: (
+              type: 'change',
+              h: (state: AppStateStatus) => void
+            ) => void;
+          }
+        ).removeEventListener?.('change', handler);
+      }
+    };
   }, []);
 
   // A dead render process can't complete an OAuth (the old isOAuthInProgress

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -1,4 +1,4 @@
-import { Linking, View } from 'react-native';
+import { AppState, Linking, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -66,11 +66,29 @@ export const LinkConnect = (props: LinkConfiguration) => {
   } = useSDKCallbacks(props);
   const webViewRef = useRef<WebView>(null);
   const hasAutoReloaded = useRef(false);
+  // Set when the WebView render process dies (e.g. Android reclaims memory
+  // while the app is backgrounded during an external OAuth hand-off). Used to
+  // recover the dead WebView when the app returns to the foreground.
+  const rendererGone = useRef(false);
   const goBack = () => webViewRef?.current?.goBack();
 
   useEffect(() => {
     hasAutoReloaded.current = false;
   }, [linkUrl]);
+
+  // Recover a dead WebView on foreground return. If the render process was
+  // killed while backgrounded (memory pressure during an external OAuth trip),
+  // reload once when the user comes back so the flow isn't stuck on a blank
+  // WebView with the in-progress session silently lost.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', state => {
+      if (state === 'active' && rendererGone.current) {
+        rendererGone.current = false;
+        webViewRef.current?.reload();
+      }
+    });
+    return () => sub.remove();
+  }, []);
 
   const injectedScript = useMemo(() => {
     let sdkTypeScript = `
@@ -205,13 +223,19 @@ export const LinkConnect = (props: LinkConfiguration) => {
             }
           }}
           onContentProcessDidTerminate={() => {
-            if (!isOAuthInProgress.current && !hasAutoReloaded.current) {
+            // Renderer process died. Reload REGARDLESS of isOAuthInProgress: a
+            // dead renderer can't complete an OAuth, so the old guard just left
+            // a blank/stuck WebView. Mark it so AppState can also recover if
+            // we're backgrounded right now.
+            rendererGone.current = true;
+            if (!hasAutoReloaded.current) {
               hasAutoReloaded.current = true;
               webViewRef.current?.reload();
             }
           }}
           onRenderProcessGone={() => {
-            if (!isOAuthInProgress.current && !hasAutoReloaded.current) {
+            rendererGone.current = true;
+            if (!hasAutoReloaded.current) {
               hasAutoReloaded.current = true;
               webViewRef.current?.reload();
             }


### PR DESCRIPTION
## Overview

[PRG-32](https://linear.app/meshconnect/issue/PRG-32) - recover the Link WebView after a render-process death during OAuth

When Android reclaims memory while the app is backgrounded during an external OAuth hand-off, the WebView render process can be killed. The renderer-death handlers (`onRenderProcessGone` / `onContentProcessDidTerminate`) skipped the reload while an OAuth was in progress, and nothing recovered on return, so the widget was left on a blank/stuck WebView and the in-progress deposit appeared lost.

- Reload on genuine renderer death regardless of `isOAuthInProgress` (a dead renderer can't complete an OAuth; the guard only stranded the flow).
- Add an `AppState` "active" listener that reloads a dead WebView on foreground return.
- Update the renderer-death tests to the new behavior + add an AppState recovery test.

### 🎨 Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing functionality affected)
- [ ] Maintenance (tests, build, tooling, performance)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

### 👌 Checklist

- [ ] I've performed a self-review, and it meets ticket criteria.
- [ ] I've commented hard-to-understand areas.
- [ ] I've updated documentation where necessary.
- [ ] I've added tests that prove the fix or feature works.
- [ ] I've tested the changes on a physical device or emulator.


[PRG-32]: https://meshconnectapi.atlassian.net/browse/PRG-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ