### PR TITLE
PRG-34: post frontAccessTokens from the RN SDK for return-user skip-login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Mesh Connect React Native SDK are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.4.9
+
+### Fixed
+
+- React Native: return-user (Managed Token) skip-login now works. Previously connected accounts passed via `settings.accessTokens` are handed to the Link web app once it loads, so returning users skip re-authentication where the broker supports it (most visibly Binance Direct), matching the web SDK.
+
 ## 2.4.8
 
 ### Fixed

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshconnect-react-native-example",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.8",
+  "version": "2.4.9",
   "name": "@meshconnect/react-native-link-sdk",
   "description": "Mesh Connect React Native SDK.",
   "license": "MIT",

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -451,7 +451,10 @@ describe('LinkConnect Component', () => {
     // Link reports it has loaded -> the SDK hands it the injected accounts, the
     // same way the web SDK posts frontAccessTokens.
     getByTestId('webview').props.onMessage({
-      nativeEvent: { data: JSON.stringify({ type: 'loaded' }) },
+      nativeEvent: {
+        data: JSON.stringify({ type: 'loaded' }),
+        url: 'https://web.getfront.com/broker-connect/catalog1',
+      },
     });
     expect(mockInjectJavaScript).toHaveBeenCalledTimes(1);
     const injected = mockInjectJavaScript.mock.calls[0][0] as string;
@@ -465,7 +468,10 @@ describe('LinkConnect Component', () => {
     const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
     await waitFor(() => getByTestId('webview'));
     getByTestId('webview').props.onMessage({
-      nativeEvent: { data: JSON.stringify({ type: 'loaded' }) },
+      nativeEvent: {
+        data: JSON.stringify({ type: 'loaded' }),
+        url: 'https://web.getfront.com/broker-connect/catalog1',
+      },
     });
     expect(mockInjectJavaScript).not.toHaveBeenCalled();
   });
@@ -486,6 +492,30 @@ describe('LinkConnect Component', () => {
     await waitFor(() => getByTestId('webview'));
     getByTestId('webview').props.onMessage({
       nativeEvent: { data: JSON.stringify({ type: 'integrationConnected' }) },
+    });
+    expect(mockInjectJavaScript).not.toHaveBeenCalled();
+  });
+
+  it('does not post frontAccessTokens when loaded comes from a different origin', async () => {
+    const accessTokens = [
+      {
+        accountId: 'acc-1',
+        accountName: 'Test Account',
+        accessToken: 'tok-abc',
+        brokerType: 'binanceInternationalDirect',
+        brokerName: 'Binance',
+      },
+    ];
+    const { getByTestId } = render(
+      <LinkConnect linkToken={SAMPLE_LINK_TOKEN} settings={{ accessTokens }} />
+    );
+    await waitFor(() => getByTestId('webview'));
+    // A loaded event from a page on a different origin must not receive tokens.
+    getByTestId('webview').props.onMessage({
+      nativeEvent: {
+        data: JSON.stringify({ type: 'loaded' }),
+        url: 'https://evil.example.com/phish',
+      },
     });
     expect(mockInjectJavaScript).not.toHaveBeenCalled();
   });

--- a/src/__tests__/LinkConnect.test.tsx
+++ b/src/__tests__/LinkConnect.test.tsx
@@ -14,13 +14,17 @@ jest.mock('react-native/Libraries/Utilities/useColorScheme', () => {
 
 // var avoids TDZ — the closure inside forwardRef reads this after module init
 var mockReload = jest.fn();
+var mockInjectJavaScript = jest.fn();
 
 jest.mock('react-native-webview', () => {
   const React = require('react');
   const { View } = require('react-native');
   return {
     WebView: React.forwardRef((props: any, ref: any) => {
-      React.useImperativeHandle(ref, () => ({ reload: mockReload }));
+      React.useImperativeHandle(ref, () => ({
+        reload: mockReload,
+        injectJavaScript: mockInjectJavaScript,
+      }));
       return React.createElement(View, props);
     }),
   };
@@ -34,6 +38,7 @@ const SAMPLE_LINK_TOKEN =
 describe('LinkConnect Component', () => {
   beforeEach(() => {
     mockReload.mockClear();
+    mockInjectJavaScript.mockClear();
     jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
     // Default to foreground; the backgrounded-recovery test overrides this.
     (AppState as any).currentState = 'active';
@@ -427,5 +432,61 @@ describe('LinkConnect Component', () => {
     // A later, unrelated foreground must not fire a spurious reload.
     appStateCb?.('active');
     expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('posts frontAccessTokens to the web app on the loaded event when accessTokens are provided', async () => {
+    const accessTokens = [
+      {
+        accountId: 'acc-1',
+        accountName: 'Test Account',
+        accessToken: 'tok-abc',
+        brokerType: 'binanceInternationalDirect',
+        brokerName: 'Binance',
+      },
+    ];
+    const { getByTestId } = render(
+      <LinkConnect linkToken={SAMPLE_LINK_TOKEN} settings={{ accessTokens }} />
+    );
+    await waitFor(() => getByTestId('webview'));
+    // Link reports it has loaded -> the SDK hands it the injected accounts, the
+    // same way the web SDK posts frontAccessTokens.
+    getByTestId('webview').props.onMessage({
+      nativeEvent: { data: JSON.stringify({ type: 'loaded' }) },
+    });
+    expect(mockInjectJavaScript).toHaveBeenCalledTimes(1);
+    const injected = mockInjectJavaScript.mock.calls[0][0] as string;
+    expect(injected).toContain('window.postMessage');
+    expect(injected).toContain('frontAccessTokens');
+    expect(injected).toContain('tok-abc');
+    expect(injected).toContain('binanceInternationalDirect');
+  });
+
+  it('does not post frontAccessTokens on loaded when no accessTokens are provided', async () => {
+    const { getByTestId } = render(<LinkConnect linkToken={SAMPLE_LINK_TOKEN} />);
+    await waitFor(() => getByTestId('webview'));
+    getByTestId('webview').props.onMessage({
+      nativeEvent: { data: JSON.stringify({ type: 'loaded' }) },
+    });
+    expect(mockInjectJavaScript).not.toHaveBeenCalled();
+  });
+
+  it('does not post frontAccessTokens for non-loaded messages', async () => {
+    const accessTokens = [
+      {
+        accountId: 'acc-1',
+        accountName: 'Test Account',
+        accessToken: 'tok-abc',
+        brokerType: 'binanceInternationalDirect',
+        brokerName: 'Binance',
+      },
+    ];
+    const { getByTestId } = render(
+      <LinkConnect linkToken={SAMPLE_LINK_TOKEN} settings={{ accessTokens }} />
+    );
+    await waitFor(() => getByTestId('webview'));
+    getByTestId('webview').props.onMessage({
+      nativeEvent: { data: JSON.stringify({ type: 'integrationConnected' }) },
+    });
+    expect(mockInjectJavaScript).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
+++ b/src/__tests__/__snapshots__/LinkConnect.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`LinkConnect Component renders correctly when linkToken is provided 1`] 
         domStorageEnabled={true}
         injectedJavaScript="
     window.meshSdkPlatform='reactNative';
-    window.meshSdkVersion='2.4.8';
+    window.meshSdkVersion='2.4.9';
   "
         javaScriptCanOpenWindowsAutomatically={true}
         javaScriptEnabled={true}

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -133,6 +133,8 @@ export const LinkConnect = (props: LinkConfiguration) => {
   `;
 
     if (props.settings) {
+      // Kept for backward-compat with older Link builds that read this global.
+      // Current Link ingests tokens via the frontAccessTokens post below.
       sdkTypeScript += `
         window.accessTokens='${JSON.stringify(
           props.settings.accessTokens || []
@@ -144,15 +146,25 @@ export const LinkConnect = (props: LinkConfiguration) => {
   }, [props.settings]);
 
   // Hand the Link web app any previously-connected accounts once it reports it
-  // has loaded, mirroring the web SDK. link-v2 ingests return-user tokens only
-  // via this `frontAccessTokens` message; it no longer reads the
-  // `window.accessTokens` global above, so without this post React Native return
-  // users never skip login. In a WebView `document.referrer` is empty, so Link's
-  // bridge targetOrigin is '*' and accepts a same-window post. Double-encoded so
-  // token values cannot break out of the injected script.
-  const postFrontAccessTokens = () => {
+  // has loaded, mirroring the web SDK. Current Link ingests return-user tokens
+  // only via this `frontAccessTokens` message (the `window.accessTokens` global
+  // above is backward-compat only), so without this post React Native return
+  // users never skip login. Only inject into the page we actually loaded from
+  // the link token (same origin) and fail closed otherwise, so a page on a
+  // different origin can never trigger a token hand-off. In a WebView
+  // `document.referrer` is empty, so Link's bridge targetOrigin is '*' and
+  // accepts the same-window post. Double-encoded so token values cannot break
+  // out of the injected script.
+  const postFrontAccessTokens = (senderUrl?: string) => {
     const tokens = props.settings?.accessTokens;
-    if (!tokens || tokens.length === 0) {
+    if (!tokens || tokens.length === 0 || !linkUrl || !senderUrl) {
+      return;
+    }
+    try {
+      if (new URL(senderUrl).origin !== new URL(linkUrl).origin) {
+        return;
+      }
+    } catch {
       return;
     }
     const message = JSON.stringify({
@@ -164,18 +176,17 @@ export const LinkConnect = (props: LinkConfiguration) => {
     );
   };
 
-  // When Link signals it has loaded, post the injected accessTokens before
-  // delegating to the normal SDK message handler. Parse once and bail on a
-  // non-JSON payload — handleMessage would only re-throw on the same input.
+  // When Link signals it has loaded, hand it the injected accessTokens, then
+  // delegate to the normal SDK handler. The parse here only drives the `loaded`
+  // check; `handleMessage` still processes every event as before, so delegation
+  // behaviour is unchanged.
   const handleWebViewMessage = (event: WebViewMessageEvent) => {
-    let data: { type?: string } | undefined;
     try {
-      data = JSON.parse(event.nativeEvent.data);
+      if (JSON.parse(event.nativeEvent.data)?.type === 'loaded') {
+        postFrontAccessTokens(event.nativeEvent.url);
+      }
     } catch {
-      return;
-    }
-    if (data?.type === 'loaded') {
-      postFrontAccessTokens();
+      // Only our `loaded` detection; the SDK handler below owns the payload.
     }
     handleMessage(event);
   };

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -135,7 +135,7 @@ export const LinkConnect = (props: LinkConfiguration) => {
     if (props.settings) {
       sdkTypeScript += `
         window.accessTokens='${JSON.stringify(
-          props.settings.accessTokens || {}
+          props.settings.accessTokens || []
         )}';
       `;
     }
@@ -165,14 +165,17 @@ export const LinkConnect = (props: LinkConfiguration) => {
   };
 
   // When Link signals it has loaded, post the injected accessTokens before
-  // delegating to the normal SDK message handler.
+  // delegating to the normal SDK message handler. Parse once and bail on a
+  // non-JSON payload — handleMessage would only re-throw on the same input.
   const handleWebViewMessage = (event: WebViewMessageEvent) => {
+    let data: { type?: string } | undefined;
     try {
-      if (JSON.parse(event.nativeEvent.data)?.type === 'loaded') {
-        postFrontAccessTokens();
-      }
+      data = JSON.parse(event.nativeEvent.data);
     } catch {
-      // Non-JSON or unexpected payload: fall through to the SDK handler.
+      return;
+    }
+    if (data?.type === 'loaded') {
+      postFrontAccessTokens();
     }
     handleMessage(event);
   };

--- a/src/components/LinkConnect.tsx
+++ b/src/components/LinkConnect.tsx
@@ -1,6 +1,6 @@
 import { AppState, Linking, View } from 'react-native';
 import type { AppStateStatus } from 'react-native';
-import { WebView } from 'react-native-webview';
+import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { NavBar } from './NavBar';
@@ -143,6 +143,40 @@ export const LinkConnect = (props: LinkConfiguration) => {
     return sdkTypeScript;
   }, [props.settings]);
 
+  // Hand the Link web app any previously-connected accounts once it reports it
+  // has loaded, mirroring the web SDK. link-v2 ingests return-user tokens only
+  // via this `frontAccessTokens` message; it no longer reads the
+  // `window.accessTokens` global above, so without this post React Native return
+  // users never skip login. In a WebView `document.referrer` is empty, so Link's
+  // bridge targetOrigin is '*' and accepts a same-window post. Double-encoded so
+  // token values cannot break out of the injected script.
+  const postFrontAccessTokens = () => {
+    const tokens = props.settings?.accessTokens;
+    if (!tokens || tokens.length === 0) {
+      return;
+    }
+    const message = JSON.stringify({
+      type: 'frontAccessTokens',
+      payload: tokens,
+    });
+    webViewRef.current?.injectJavaScript(
+      `window.postMessage(JSON.parse(${JSON.stringify(message)}), '*'); true;`
+    );
+  };
+
+  // When Link signals it has loaded, post the injected accessTokens before
+  // delegating to the normal SDK message handler.
+  const handleWebViewMessage = (event: WebViewMessageEvent) => {
+    try {
+      if (JSON.parse(event.nativeEvent.data)?.type === 'loaded') {
+        postFrontAccessTokens();
+      }
+    } catch {
+      // Non-JSON or unexpected payload: fall through to the SDK handler.
+    }
+    handleMessage(event);
+  };
+
   const SDKWrapperComponent = props.renderViewContainer
     ? SDKViewContainer
     : SDKContainer;
@@ -181,7 +215,7 @@ export const LinkConnect = (props: LinkConfiguration) => {
           ref={webViewRef}
           source={{ uri: linkUrl }}
           cacheMode={'LOAD_DEFAULT'}
-          onMessage={handleMessage}
+          onMessage={handleWebViewMessage}
           onLoadEnd={() => {
             setInitialLoading(false);
           }}


### PR DESCRIPTION
## Overview

[PRG-34](https://linear.app/meshconnect/issue/PRG-34) - React Native return-user (Managed Token) skip-login. Related: CARE-325 (Kraken repro).

link-v2 ingests previously-connected `accessTokens` only via the `frontAccessTokens` postMessage (the path the web SDK uses). The RN SDK only set the legacy `window.accessTokens` global, which link-v2 no longer reads, so React Native return users never skipped login (Kraken: Binance re-auths every deposit on Android; web is fine). On Link's `loaded` event the SDK now posts `frontAccessTokens` into the WebView carrying `settings.accessTokens`, mirroring the web SDK. Web SDK untouched; no link-v2 change needed; reaches integrators on SDK upgrade. Bumped to 2.4.9.

### 🎨 Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing functionality affected)
- [ ] Maintenance (tests, build, tooling, performance)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

### 👌 Checklist

- [ ] I've performed a self-review, and it meets ticket criteria.
- [ ] I've commented hard-to-understand areas.
- [ ] I've updated documentation where necessary.
- [ ] I've added tests that prove the fix or feature works.
- [ ] I've tested the changes on a physical device or emulator.
